### PR TITLE
Refactored ModCatalog and VersionCatalog to store catalogs as ImmutableArray

### DIFF
--- a/src/Restall.Application/Common/Result.cs
+++ b/src/Restall.Application/Common/Result.cs
@@ -16,11 +16,11 @@ public sealed record Result(bool IsSuccess, string? ErrorMessage = null,
 }
 
 /// <summary>
-/// A custom Result type which can be used as Result<![CDATA[<T>]]> to return a value. Auto-sets IsSuccess bool on Ok or Err.
+/// A custom Result type which can be used as Result<![CDATA[<T>]]> to return a value. Auto-sets IsSuccess bool on Success or Error.
 /// Use this type to easily return messages, errors and exceptions to propagate them for useful logging and user facing messages.
 /// <br/><br/>
 /// The messages returned by this type should be useful for logging and not be used to write messages to users. Instead, 
-/// return a ResultError with Result.Err and match on the ResultError in a switch expression at UseCase level to write manual user-friendly messages.
+/// return a ErrorType with Result.Error and match on the ErrorType in a switch expression at UseCase level to write manual user-friendly messages.
 /// </summary>
 public sealed record Result<T>(bool IsSuccess, T? Value = default, string? ErrorMessage = null,
     Exception? Exception = null,  ErrorType ErrorType = ErrorType.Unknown)

--- a/src/Restall.Application/DTOs/Results/RenoDXWikiParseResultDto.cs
+++ b/src/Restall.Application/DTOs/Results/RenoDXWikiParseResultDto.cs
@@ -1,6 +1,8 @@
-﻿namespace Restall.Application.DTOs.Results;
+﻿using System.Collections.Immutable;
+
+namespace Restall.Application.DTOs.Results;
 
 public record RenoDXWikiParseResultDto(
-    IReadOnlyList<RenoDXModInfoDto> WikiMods,
-    IReadOnlyList<RenoDXGenericModInfoDto> GenericWikiMods
+    ImmutableArray<RenoDXModInfoDto> WikiMods,
+    ImmutableArray<RenoDXGenericModInfoDto> GenericWikiMods
 );

--- a/src/Restall.Application/Interfaces/Driven/IModCatalog.cs
+++ b/src/Restall.Application/Interfaces/Driven/IModCatalog.cs
@@ -1,4 +1,5 @@
-﻿using Restall.Application.DTOs;
+﻿using System.Collections.Immutable;
+using Restall.Application.DTOs;
 
 namespace Restall.Application.Interfaces.Driven;
 
@@ -6,6 +7,6 @@ public interface IModCatalog
 {
     Task FetchModsAsync();
 
-    IReadOnlyList<RenoDXModInfoDto> GetRenoDXWikiMods();
-    IReadOnlyList<RenoDXGenericModInfoDto> GetRenoDXGenericWikiMods();
+    ImmutableArray<RenoDXModInfoDto> GetRenoDXWikiMods();
+    ImmutableArray<RenoDXGenericModInfoDto> GetRenoDXGenericWikiMods();
 }

--- a/src/Restall.Application/Interfaces/Driven/IParseService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IParseService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;
 
@@ -5,9 +6,9 @@ namespace Restall.Application.Interfaces.Driven;
 
 public interface IParseService
 {
-    Task<IReadOnlyList<string>> FetchReShadeVersionsAsync();
+    Task<ImmutableArray<string>> FetchReShadeVersionsAsync();
 
     Task<RenoDXWikiParseResultDto> FetchRenoDXWikiModsAsync();
     Task<RenoDXTagInfoDto?> FetchRenoDXSnapshotAsync();
-    Task<IReadOnlyList<RenoDXTagInfoDto>> FetchRenoDXNightlyTagsAsync();
+    Task<ImmutableArray<RenoDXTagInfoDto>> FetchRenoDXNightlyTagsAsync();
 }

--- a/src/Restall.Application/Interfaces/Driven/IVersionCatalog.cs
+++ b/src/Restall.Application/Interfaces/Driven/IVersionCatalog.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Restall.Application.DTOs;
 using Restall.Domain.Entities;
 
@@ -8,8 +9,8 @@ public interface IVersionCatalog
     Task FetchVersionsAsync();
 
     string? GetLatestReShadeVersion(ReShade.Branch branch);
-    IReadOnlyList<string> GetAvailableReShadeVersions(ReShade.Branch branch);
+    ImmutableArray<string> GetAvailableReShadeVersions(ReShade.Branch branch);
 
     RenoDXTagInfoDto? GetLatestRenoDXVersionByTag(RenoDX.Branch branch);
-    IReadOnlyList<RenoDXTagInfoDto> GetAllRenoDXNightlies();
+    ImmutableArray<RenoDXTagInfoDto> GetAllRenoDXNightlies();
 }

--- a/src/Restall.Application/UseCases/RefreshLibraryUseCase.cs
+++ b/src/Restall.Application/UseCases/RefreshLibraryUseCase.cs
@@ -1,4 +1,5 @@
-﻿using Restall.Application.DTOs;
+﻿using System.Collections.Immutable;
+using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;
 using Restall.Application.Helpers;
 using Restall.Application.Interfaces.Driven;
@@ -99,7 +100,7 @@ public sealed class RefreshLibraryUseCase : IRefreshLibraryUseCase, ILightRefres
         return new RefreshLibraryResultDto(results, success, errorMessage);
     }
 
-    private static RenoDXModInfoDto? FindCompatibleMod(string? gameName, IReadOnlyList<RenoDXModInfoDto> mods)
+    private static RenoDXModInfoDto? FindCompatibleMod(string? gameName, ImmutableArray<RenoDXModInfoDto> mods)
     {
         if (string.IsNullOrWhiteSpace(gameName)) return null;
 
@@ -111,7 +112,7 @@ public sealed class RefreshLibraryUseCase : IRefreshLibraryUseCase, ILightRefres
     }
 
     private static RenoDXGenericModInfoDto? FindGenericMod(string? gameName,
-        IReadOnlyList<RenoDXGenericModInfoDto> mods)
+        ImmutableArray<RenoDXGenericModInfoDto> mods)
     {
         if (string.IsNullOrWhiteSpace(gameName)) return null;
 

--- a/src/Restall.Infrastructure/Services/ParseService.cs
+++ b/src/Restall.Infrastructure/Services/ParseService.cs
@@ -1,4 +1,5 @@
-﻿using HtmlAgilityPack;
+﻿using System.Collections.Immutable;
+using HtmlAgilityPack;
 using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;
 using Restall.Application.Interfaces.Driven;
@@ -32,7 +33,7 @@ internal sealed class ParseService : IParseService
         _httpClientFactory = httpClientFactory;
     }
 
-    public async Task<IReadOnlyList<string>> FetchReShadeVersionsAsync()
+    public async Task<ImmutableArray<string>> FetchReShadeVersionsAsync()
     {
         var versions = await FetchReShadeVersionsFromGitHubTagsAsync();
         var siteVersion = await FetchLatestReShadeVersionFromSiteAsync();
@@ -45,7 +46,7 @@ internal sealed class ParseService : IParseService
 
         await _logService.LogInfoAsync(
             $"Fetched {versions.Count} stable ReShade versions. Latest: {versions.FirstOrDefault()}");
-        return versions;
+        return [..versions];
     }
 
     public async Task<RenoDXTagInfoDto?> FetchRenoDXSnapshotAsync()
@@ -112,20 +113,20 @@ internal sealed class ParseService : IParseService
         }
     }
 
-    public async Task<IReadOnlyList<RenoDXTagInfoDto>> FetchRenoDXNightlyTagsAsync()
+    public async Task<ImmutableArray<RenoDXTagInfoDto>> FetchRenoDXNightlyTagsAsync()
     {
         var nightlyTags = await FetchRenoDXNightlyTagNamesAsync();
 
-        if (nightlyTags.Count <= 0)
+        if (nightlyTags.Length <= 0)
         {
             await _logService.LogWarningAsync("No nightly RenoDX tags found.");
             return [];
         }
 
         var tagInfoResults = await Task.WhenAll(nightlyTags.Select(FetchRenoDXNighlyReleaseInfoAsync));
-        var tagInfos = tagInfoResults.OfType<RenoDXTagInfoDto>().ToList();
+        var tagInfos = tagInfoResults.OfType<RenoDXTagInfoDto>().ToImmutableArray();
 
-        await _logService.LogInfoAsync($"Fetched {tagInfos.Count} nightly RenoDX versions. " +
+        await _logService.LogInfoAsync($"Fetched {tagInfos.Length} nightly RenoDX versions. " +
                                        $"Latest: {tagInfos.FirstOrDefault()?.Version}");
         return tagInfos;
     }
@@ -238,7 +239,7 @@ internal sealed class ParseService : IParseService
             await _logService.LogErrorAsync("Request for RenoDX wiki page timed out.", ex);
         }
 
-        return new RenoDXWikiParseResultDto(wikiMods, genericWikiMods);
+        return new RenoDXWikiParseResultDto([..wikiMods], [..genericWikiMods]);
     }
 
     private static string ExtractMarkdownLinkText(string text)
@@ -337,7 +338,7 @@ internal sealed class ParseService : IParseService
         return versions;
     }
 
-    private async Task<List<string>> FetchRenoDXNightlyTagNamesAsync(string? pageUrl = null)
+    private async Task<ImmutableArray<string>> FetchRenoDXNightlyTagNamesAsync(string? pageUrl = null)
     {
         var tags = new List<string>();
 
@@ -351,7 +352,7 @@ internal sealed class ParseService : IParseService
             if (tagNodes is null)
             {
                 await _logService.LogWarningAsync("No nightly tag links found on RenoDX tags page.");
-                return tags;
+                return ImmutableArray<string>.Empty;
             }
 
             foreach (var node in tagNodes)
@@ -367,15 +368,15 @@ internal sealed class ParseService : IParseService
         catch (HttpRequestException ex)
         {
             await _logService.LogErrorAsync($"GitHub tags page for RenoDX is unreachable. ({(int?)ex.StatusCode})", ex);
-            return tags;
+            return [..tags];
         }
         catch (TaskCanceledException ex)
         {
             await _logService.LogErrorAsync("GitHub tags page for RenoDX timed out.", ex);
-            return tags;
+            return [..tags];
         }
 
-        return tags;
+        return [..tags];
     }
 
     private async Task<RenoDXTagInfoDto?> FetchRenoDXNighlyReleaseInfoAsync(string nightlyTag)

--- a/src/Restall.Infrastructure/Stores/ModCatalog.cs
+++ b/src/Restall.Infrastructure/Stores/ModCatalog.cs
@@ -1,4 +1,5 @@
-﻿using Restall.Application.DTOs;
+﻿using System.Collections.Immutable;
+using Restall.Application.DTOs;
 using Restall.Application.Interfaces.Driven;
 
 namespace Restall.Infrastructure.Stores;
@@ -7,8 +8,8 @@ internal sealed class ModCatalog : IModCatalog
 {
     private readonly IParseService _parseService;
 
-    private IReadOnlyList<RenoDXModInfoDto> _renoDXWikiMods = [];
-    private IReadOnlyList<RenoDXGenericModInfoDto> _renoDXGenericWikiMods = [];
+    private ImmutableArray<RenoDXModInfoDto> _renoDXWikiMods = [];
+    private ImmutableArray<RenoDXGenericModInfoDto> _renoDXGenericWikiMods = [];
 
     public ModCatalog(
         IParseService parseService
@@ -25,7 +26,7 @@ internal sealed class ModCatalog : IModCatalog
         _renoDXGenericWikiMods = result.GenericWikiMods;
     }
 
-    public IReadOnlyList<RenoDXModInfoDto> GetRenoDXWikiMods() => _renoDXWikiMods;
+    public ImmutableArray<RenoDXModInfoDto> GetRenoDXWikiMods() => _renoDXWikiMods;
 
-    public IReadOnlyList<RenoDXGenericModInfoDto> GetRenoDXGenericWikiMods() => _renoDXGenericWikiMods;
+    public ImmutableArray<RenoDXGenericModInfoDto> GetRenoDXGenericWikiMods() => _renoDXGenericWikiMods;
 }

--- a/src/Restall.Infrastructure/Stores/VersionCatalog.cs
+++ b/src/Restall.Infrastructure/Stores/VersionCatalog.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Restall.Application.DTOs;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;
@@ -9,8 +10,8 @@ internal sealed class VersionCatalog : IVersionCatalog
     private readonly IParseService _parseService;
     private readonly ILogService _logService;
 
-    private readonly Dictionary<ReShade.Branch, IReadOnlyList<string>> _reShadeVersions = [];
-    private readonly Dictionary<RenoDX.Branch, IReadOnlyList<RenoDXTagInfoDto>> _renoDXTags = [];
+    private ImmutableDictionary<ReShade.Branch, ImmutableArray<string>> _reShadeVersions = ImmutableDictionary<ReShade.Branch, ImmutableArray<string>>.Empty;
+    private ImmutableDictionary<RenoDX.Branch, ImmutableArray<RenoDXTagInfoDto>> _renoDXTags = ImmutableDictionary<RenoDX.Branch, ImmutableArray<RenoDXTagInfoDto>>.Empty;
 
     public VersionCatalog(
         IParseService parseService,
@@ -23,47 +24,47 @@ internal sealed class VersionCatalog : IVersionCatalog
 
     public async Task FetchVersionsAsync()
     {
-        _reShadeVersions.Clear();
-        _renoDXTags.Clear();
-
         var reShadeVersionsTask = _parseService.FetchReShadeVersionsAsync();
         var renoDXSnapshotTask = _parseService.FetchRenoDXSnapshotAsync();
         var renoDXNightlyTask = _parseService.FetchRenoDXNightlyTagsAsync();
 
         await Task.WhenAll(reShadeVersionsTask, renoDXSnapshotTask, renoDXNightlyTask);
 
-        _reShadeVersions[ReShade.Branch.Stable] = reShadeVersionsTask.Result;
+        _reShadeVersions = ImmutableDictionary<ReShade.Branch, ImmutableArray<string>>.Empty
+            .Add(ReShade.Branch.Stable, reShadeVersionsTask.Result);
 
+        var renoDXBuilder = ImmutableDictionary.CreateBuilder<RenoDX.Branch, ImmutableArray<RenoDXTagInfoDto>>();
         if (renoDXSnapshotTask.Result is not null)
-            _renoDXTags[RenoDX.Branch.Snapshot] = [renoDXSnapshotTask.Result];
-
-        _renoDXTags[RenoDX.Branch.Nightly] = [..renoDXNightlyTask.Result];
+            renoDXBuilder[RenoDX.Branch.Snapshot] = [renoDXSnapshotTask.Result];
+        
+        renoDXBuilder[RenoDX.Branch.Nightly] = renoDXNightlyTask.Result;
+        _renoDXTags = renoDXBuilder.ToImmutable();
 
         await _logService.LogInfoAsync($"Version catalog populated. " +
-            $"ReShade {reShadeVersionsTask.Result.Count} versions. " +
+            $"ReShade {reShadeVersionsTask.Result.Length} versions. " +
             $"RenoDX Snapshot: {(renoDXSnapshotTask.Result is not null ? renoDXSnapshotTask.Result.Version : "none")}. " +
-            $"RenoDX Nightly: {renoDXNightlyTask.Result.Count} tags.");
+            $"RenoDX Nightly: {renoDXNightlyTask.Result.Length} tags.");
     }
 
     public string? GetLatestReShadeVersion(ReShade.Branch branch)
     {
-        if (!_reShadeVersions.TryGetValue(branch, out var versions) || versions.Count == 0)
+        if (!_reShadeVersions.TryGetValue(branch, out var versions) || versions.Length == 0)
             return null;
 
         return versions[0];
     }
 
-    public IReadOnlyList<string> GetAvailableReShadeVersions(ReShade.Branch branch) =>
+    public ImmutableArray<string> GetAvailableReShadeVersions(ReShade.Branch branch) =>
         _reShadeVersions.TryGetValue(branch, out var versions) ? versions : [];
 
     public RenoDXTagInfoDto? GetLatestRenoDXVersionByTag(RenoDX.Branch branch)
     {
-        if (!_renoDXTags.TryGetValue(branch, out var versions) || versions.Count == 0)
+        if (!_renoDXTags.TryGetValue(branch, out var versions) || versions.Length == 0)
             return null;
 
         return versions[0];
     }
 
-    public IReadOnlyList<RenoDXTagInfoDto> GetAllRenoDXNightlies() =>
+    public ImmutableArray<RenoDXTagInfoDto> GetAllRenoDXNightlies() =>
         _renoDXTags.TryGetValue(RenoDX.Branch.Nightly, out var versions) ? versions : [];
 }

--- a/src/Restall.UI/Services/ModSelectionDialogService.cs
+++ b/src/Restall.UI/Services/ModSelectionDialogService.cs
@@ -33,7 +33,7 @@ public sealed class ModSelectionDialogService : IModSelectionDialogService
 
         var versions = _versionCatalog.GetAvailableReShadeVersions(ReShade.Branch.Stable);
 
-        if (versions.Count == 0)
+        if (versions.Length == 0)
         {
             await _logService.LogWarningAsync("No ReShade versions available.");
             return null;
@@ -56,7 +56,7 @@ public sealed class ModSelectionDialogService : IModSelectionDialogService
 
         var versions = _versionCatalog.GetAllRenoDXNightlies();
 
-        if (versions.Count == 0)
+        if (versions.Length == 0)
         {
             await _logService.LogWarningAsync("No RenoDX nightlies available.");
             return null;

--- a/src/Restall.UI/ViewModels/ModViewModel.cs
+++ b/src/Restall.UI/ViewModels/ModViewModel.cs
@@ -21,6 +21,9 @@ public sealed partial class ModViewModel : ViewModelBase
     private readonly IModSelectionDialogService _modSelectionDialogService;
     private readonly IVersionCatalog _versionCatalog;
 
+    private const string s_upToDateTextColor = "#eb5a2f";
+    private const string s_updateAvailableTextColor = "#1ab652";
+
     public ModViewModel(
         IModManagementFacade modManagementFacade,
         IModSelectionDialogService modSelectionDialogService,
@@ -190,7 +193,7 @@ public sealed partial class ModViewModel : ViewModelBase
 
     public string? ReShadeVersionTextColor =>
         SelectedGame?.HasReShade == true
-            ? (CanShowReShadeUpdate ? "#eb5a2f" : "#1ab652")
+            ? (CanShowReShadeUpdate ? s_upToDateTextColor : s_updateAvailableTextColor)
             : null;
 
     public string InstallReShadeButtonText =>
@@ -361,7 +364,7 @@ public sealed partial class ModViewModel : ViewModelBase
 
     public string? RenoDXVersionTextColor =>
         SelectedGame?.HasRenoDX == true
-            ? (CanShowRenoDXUpdate ? "#eb5a2f" : "#1ab652")
+            ? (CanShowRenoDXUpdate ? s_upToDateTextColor : s_updateAvailableTextColor)
             : null;
 
     public string InstallRenoDXButtonText =>


### PR DESCRIPTION
Refactored collection usage in catalogs to use immutable collections. Should in theory optimize heap allocation by telling the compiler that these collection will not change during runtime. ParseService builds these using mutable collections and then returns immutable variants to the catalogs. GC cleans up the collections created by the parse methods when they go out of scope.