### PR TITLE
xbox feature

### DIFF
--- a/src/Restall.Application/Interfaces/Driven/IEngineDetectionService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IEngineDetectionService.cs
@@ -4,6 +4,6 @@ namespace Restall.Application.Interfaces.Driven;
 
 public interface IEngineDetectionService
 {
-    public (string? executablePath, Game.Engine engine) DetectExecutablePathAndEngine(string rootPath);
+    public (string? executablePath, Game.Engine engine) DetectExecutablePathAndEngine(string rootPath, Game.Platform platform);
 
 }

--- a/src/Restall.Domain/Entities/Game.cs
+++ b/src/Restall.Domain/Entities/Game.cs
@@ -2,7 +2,7 @@ namespace Restall.Domain.Entities;
 
 public sealed class Game
 {  
-    public enum Platform { Unknown, Steam, Epic, GOG, Ubisoft, EA }
+    public enum Platform { Unknown, Steam, Epic, GOG, Ubisoft, EA, Xbox }
     public enum Engine { Unknown, Unreal, Unity }
 
     public string? Name { get; init; }

--- a/src/Restall.Infrastructure/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Restall.Infrastructure/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -72,6 +72,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<IPlatformScannerService, GOGScanner>();
         services.AddSingleton<IPlatformScannerService, UbisoftScanner>();
         services.AddSingleton<IPlatformScannerService, EAScanner>();
+        services.AddSingleton<IPlatformScannerService, XboxScanner>();
         return services;
     }
     

--- a/src/Restall.Infrastructure/Scanners/XboxScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/XboxScanner.cs
@@ -1,0 +1,110 @@
+using System.Xml.Linq;
+using Restall.Application.DTOs.Results;
+using Restall.Application.Interfaces.Driven;
+using Restall.Domain.Entities;
+
+namespace Restall.Infrastructure.Scanners;
+
+internal sealed class XboxScanner : IPlatformScannerService
+{
+    private readonly ILogService _logService;
+    
+    public XboxScanner(ILogService logService)
+    {
+        _logService = logService;
+    }
+
+    public Task<GameScanResultDto> ScanAsync() => Task.Run(ScanXbox);
+    public Game.Platform Platform =>  Game.Platform.Xbox;
+    private GameScanResultDto ScanXbox()
+    {
+        var games = new List<Game>();
+        var errors = new List<string>();
+        
+        foreach (var xboxPath in GetXboxInstallPaths()) 
+        {
+            var (library, error) = ScanXboxLibrary(xboxPath);
+            games.AddRange(library);
+            if(error is not null) errors.Add(error);
+        }
+        
+        return new GameScanResultDto(
+            Platform: Game.Platform.Xbox,
+            Games: games,
+            IsSuccess: games.Count > 0,
+            Message: errors.Count > 0 ? string.Join(", ", errors) : null);
+    }
+    
+    private (List<Game> games, string? error) ScanXboxLibrary(string installPath)
+    {
+        var games = new List<Game>();
+
+        try
+        {
+            foreach (var gameDir in Directory.EnumerateDirectories(installPath))
+            {
+                try
+                {
+                    var contentDir = Path.Combine(gameDir, "Content");
+                    if (!Directory.Exists(contentDir)) continue;
+                    
+                    var configPath = Path.Combine(gameDir, "Content", "MicrosoftGame.config");
+                    if (!File.Exists(configPath)) continue;
+
+                    var (name, storeId, iconFile) = ParseMicrosoftGameConfig(configPath);
+                    
+                    var resolvedName = name ?? Path.GetFileName(gameDir);
+                    
+                    var iconPath = iconFile is not null ? Path.Combine(gameDir, "Content", iconFile) : null;
+                    
+                    if (string.IsNullOrWhiteSpace(resolvedName)) continue;
+                    
+                    games.Add(new Game
+                    {
+                        Name = resolvedName,
+                        InstallFolder = gameDir,
+                        ExecutablePath = contentDir,
+                        ThumbnailPathString = File.Exists(iconPath) ? iconPath : null,
+                        PlatformName = Platform,
+                        PlatformId = storeId
+                    });
+
+                }
+                catch (Exception ex)
+                {
+                    _logService.LogError("Failed to process Xbox Games", ex);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logService.LogError("Failed to scan Xbox Game Library", ex);
+            return (games, "Failed to scan Xbox Game Library");
+        }
+
+        return (games, null);
+    }
+
+    private static (string? name, string? storeId, string? iconFile) ParseMicrosoftGameConfig(string configPath)
+    {
+        var document = XDocument.Load(configPath);
+        var nameSpace = document.Root?.Name.Namespace ?? XNamespace.None;
+        var shellVisuals = document.Root?.Element(nameSpace + "ShellVisuals");
+        
+        var name = shellVisuals?.Attribute("DefaultDisplayName")?.Value;
+        var iconFile = shellVisuals?.Attribute("Square44x44Logo")?.Value;
+        
+        var storeId = document.Root?.Element(nameSpace + "StoreId")?.Value;
+        
+        return (name, storeId, iconFile);
+    }
+    
+    private static List<string> GetXboxInstallPaths() =>
+        DriveInfo.GetDrives()
+            .Where(d => d.DriveType == DriveType.Fixed && d.IsReady)
+            .Select(d => Path.Combine(d.RootDirectory.FullName, "XboxGames"))
+            .Where(Directory.Exists).ToList();
+    
+    
+    
+}

--- a/src/Restall.Infrastructure/Scanners/XboxScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/XboxScanner.cs
@@ -34,56 +34,51 @@ internal sealed class XboxScanner : IPlatformScannerService
             IsSuccess: games.Count > 0,
             Message: errors.Count > 0 ? string.Join(", ", errors) : null);
     }
-    
+
     private (List<Game> games, string? error) ScanXboxLibrary(string installPath)
     {
         var games = new List<Game>();
 
-        try
+        foreach (var gameDir in Directory.EnumerateDirectories(installPath))
         {
-            foreach (var gameDir in Directory.EnumerateDirectories(installPath))
+            try
             {
-                try
-                {
-                    var contentDir = Path.Combine(gameDir, "Content");
-                    if (!Directory.Exists(contentDir)) continue;
-                    
-                    var configPath = Path.Combine(gameDir, "Content", "MicrosoftGame.config");
-                    if (!File.Exists(configPath)) continue;
+                var contentDir = Path.Combine(gameDir, "Content");
+                if (!Directory.Exists(contentDir)) continue;
 
-                    var (name, storeId, iconFile) = ParseMicrosoftGameConfig(configPath);
-                    
-                    var resolvedName = name ?? Path.GetFileName(gameDir);
-                    
-                    var iconPath = iconFile is not null ? Path.Combine(gameDir, "Content", iconFile) : null;
-                    
-                    if (string.IsNullOrWhiteSpace(resolvedName)) continue;
-                    
-                    games.Add(new Game
-                    {
-                        Name = resolvedName,
-                        InstallFolder = gameDir,
-                        ExecutablePath = contentDir,
-                        ThumbnailPathString = File.Exists(iconPath) ? iconPath : null,
-                        PlatformName = Platform,
-                        PlatformId = storeId
-                    });
+                var configPath = Path.Combine(gameDir, "Content", "MicrosoftGame.config");
+                if (!File.Exists(configPath)) continue;
 
-                }
-                catch (Exception ex)
+                var (name, storeId, iconFile) = ParseMicrosoftGameConfig(configPath);
+
+                var resolvedName = name ?? Path.GetFileName(gameDir);
+
+                var iconPath = iconFile is not null ? Path.Combine(gameDir, "Content", iconFile) : null;
+
+                if (string.IsNullOrWhiteSpace(resolvedName)) continue;
+
+                games.Add(new Game
                 {
-                    _logService.LogError("Failed to process Xbox Games", ex);
-                }
+                    Name = resolvedName,
+                    InstallFolder = gameDir,
+                    ExecutablePath = contentDir,
+                    ThumbnailPathString = File.Exists(iconPath) ? iconPath : null,
+                    PlatformName = Platform,
+                    PlatformId = storeId
+                });
+
             }
-        }
-        catch (Exception ex)
-        {
-            _logService.LogError("Failed to scan Xbox Game Library", ex);
-            return (games, "Failed to scan Xbox Game Library");
-        }
+            catch (Exception ex)
+            {
+                _logService.LogError("Failed to scan Xbox Game Library", ex);
+                return (games, "Failed to scan Xbox Game Library");
+            }
 
+        }
+        
         return (games, null);
     }
+
 
     private static (string? name, string? storeId, string? iconFile) ParseMicrosoftGameConfig(string configPath)
     {

--- a/src/Restall.Infrastructure/Services/EngineDetectionService.cs
+++ b/src/Restall.Infrastructure/Services/EngineDetectionService.cs
@@ -13,22 +13,23 @@ internal sealed class EngineDetectionService : IEngineDetectionService
         _logService = logService;
     }
 
-    public (string? executablePath, Game.Engine engine) DetectExecutablePathAndEngine(string rootPath)
+    public (string? executablePath, Game.Engine engine) DetectExecutablePathAndEngine(string rootPath, Game.Platform platform)
     {
         var uePath = FindUEBinariesFolder(rootPath);
-        if (uePath != null)
-        {
-            return (uePath, Game.Engine.Unreal);
-        }
-
         var unityPlayer = FindFileShallow(rootPath, "UnityPlayer.dll", maxDepth: 2);
-        if (unityPlayer != null)
-        {
-            return (Path.GetDirectoryName(unityPlayer), Game.Engine.Unity);
-        }
 
-        var exeFolder = FindShallowExeFolder(rootPath);
-        return (exeFolder, Game.Engine.Unknown);
+        Game.Engine engine =
+            uePath != null ? Game.Engine.Unreal :
+            unityPlayer != null ? Game.Engine.Unity :
+            Game.Engine.Unknown;
+        
+        if(platform == Game.Platform.Xbox)
+            return (rootPath, engine);
+
+        if (uePath != null) return (uePath, Game.Engine.Unreal);
+        if (unityPlayer != null) return (Path.GetDirectoryName(unityPlayer), Game.Engine.Unity);
+        
+        return (FindShallowExeFolder(rootPath), Game.Engine.Unknown);
     }
 
 

--- a/src/Restall.Infrastructure/Services/GameArtworkService.cs
+++ b/src/Restall.Infrastructure/Services/GameArtworkService.cs
@@ -1,8 +1,7 @@
-using System.Text.Json;
 using Restall.Application.Helpers;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;
-using Restall.Infrastructure.Helpers;
+
 
 
 namespace Restall.Infrastructure.Services;
@@ -13,16 +12,19 @@ internal sealed class GameArtworkService : IGameArtworkService
     private readonly IPathService _pathService;
     private readonly IGameCoverService _gameCoverService;
     private readonly IGameIconService _gameIconService;
+    private readonly IImageResizeService _imageResizeService;
 
     public GameArtworkService(ILogService logService,
         IPathService pathService,
         IGameCoverService gameCoverService,
-        IGameIconService gameIconService)
+        IGameIconService gameIconService
+        , IImageResizeService imageResizeService)
     {
         _logService = logService;
         _pathService = pathService;
         _gameCoverService = gameCoverService;
         _gameIconService = gameIconService;
+        _imageResizeService = imageResizeService;
 
         Directory.CreateDirectory(pathService.GetArtworkCacheDirectory());
     }
@@ -37,10 +39,17 @@ internal sealed class GameArtworkService : IGameArtworkService
 
             Directory.CreateDirectory(Path.GetDirectoryName(coverPath)!);
             Directory.CreateDirectory(Path.GetDirectoryName(iconPath)!);
-
+            
             await _gameCoverService.DownloadCoverIfMissingAsync(game, coverPath);
-            await _gameIconService.ExtractIconIfMissingAsync(game.ExecutablePath, game.Name, iconPath);
-
+            
+            if (!File.Exists(iconPath))
+            {
+                if(game.ThumbnailPathString is not null && File.Exists(game.ThumbnailPathString))
+                    File.Copy(game.ThumbnailPathString, iconPath, overwrite: true);
+                else 
+                    await _gameIconService.ExtractIconIfMissingAsync(game.ExecutablePath, game.Name, iconPath);
+            }
+            
             game.GameCoverPathString = File.Exists(coverPath) ? coverPath : string.Empty;
             game.ThumbnailPathString = File.Exists(iconPath) ? iconPath : string.Empty;
         }

--- a/src/Restall.Infrastructure/Services/GameDetectionService.cs
+++ b/src/Restall.Infrastructure/Services/GameDetectionService.cs
@@ -64,29 +64,40 @@ internal sealed class GameDetectionService : IGameDetectionService
                   .Select(g => g.OrderByDescending(x => x.PlatformId != null).First())
                   .ToList<Game?>();
               
-              var engineCache = new ConcurrentDictionary<string, (string? path, Game.Engine engine)>(
-                  StringComparer.OrdinalIgnoreCase);
+              var engineCache = new ConcurrentDictionary<(string root, Game.Platform platform),
+              (string? path, Game.Engine engine)>();
 
               await Task.Run(() =>
               {
                   Parallel.ForEach(deduped, s_engineParallelOptions, game =>
                   {
                       if (game is null || string.IsNullOrWhiteSpace(game.InstallFolder)) return;
-
-                      var rootKey = (GameScanHelper.NormalizePath(game.InstallFolder) ?? game.InstallFolder).ToLowerInvariant();
+                      
+                      var normalized = GameScanHelper.NormalizePath(game.InstallFolder)!.ToLowerInvariant();
+                      var rootKey = (normalized, game.PlatformName);
 
                       if (engineCache.TryGetValue(rootKey, out var cached))
                       {
                           game.ExecutablePath = cached.path;
-                          game.EngineName     = cached.engine;
+                          game.EngineName = cached.engine;
                           return;
                       }
 
-                      var (executablePath, engine) =
-                          _engineDetectionService.DetectExecutablePathAndEngine(game.InstallFolder);
-                      game.ExecutablePath = executablePath;
-                      game.EngineName     = engine;
-                      engineCache[rootKey] = (executablePath, engine);
+                      if (game.PlatformName == Game.Platform.Xbox)
+                      {
+                          var (_, engine) = _engineDetectionService.DetectExecutablePathAndEngine(game.InstallFolder,
+                              game.PlatformName);
+                          game.EngineName = engine;
+                          engineCache[rootKey] = (game.ExecutablePath, engine);
+                          return;
+                      }
+                      
+                      var (executablePath, detectedEngine) =
+                          _engineDetectionService.DetectExecutablePathAndEngine(game.InstallFolder, game.PlatformName);
+                      
+                      game.ExecutablePath  = executablePath;
+                      game.EngineName = detectedEngine;
+                      engineCache[rootKey] = (executablePath, detectedEngine);
                   });
               });
               


### PR DESCRIPTION
We came to the conclusion that many are using ReShade and RenoDX mods with Xbox Game Pass, so I implemented the functionality so the users can scan their xbox library.

I went with the same procedure, but Xbox are handling their implementation differently. It goes through Local Disk rather than LocalData like with other scanners. I also saw that the users are able to put their games on different disks when installing so I made the GetInstallPath as a List and looking for the root of the fixed drives and filter those that exist, 

I then Scan the library and following the path to get to "MicrosoftGameConfig" and use a XML Document reader as all games have "DefaultDisplayName" and "StoreId" . Because Microsoft are handling their icons differently, I am forced to read the icons that's inside the config file, adding it to the list and copying the file rather than being able to parse and extract the image with PeIconHelper.

Because the installation process is different for Xbox, I was forced to update Engine- and GameDetectionService, because it went through Binaries folder for Unreal Engine games rather than landing directly in the same folder as "GameLauncherHelper.exe" is. So I am doing a Platform check if it's xbox and returning the rootpath and engine and in GameDetectionService I am doing a Platform check and checking just the engine because I am setting the ExecutablePath in the XboxScanner.

<img width="2565" height="1373" alt="xboxdemo" src="https://github.com/user-attachments/assets/6b1702ba-653d-4793-94cd-2e81f9e526f2" />





  
