### PR TITLE
Made a quick workaround for Witcher 3

### DIFF
--- a/src/Restall.Infrastructure/Helpers/GameScanHelper.cs
+++ b/src/Restall.Infrastructure/Helpers/GameScanHelper.cs
@@ -137,6 +137,7 @@ internal static class GameScanHelper
     internal static string[] GetPreferredExeSubFolders() => 
     [
         "bin",
+        Path.Combine("bin", "x64_dx12"),
         Path.Combine("bin", "x64"),
         Path.Combine("bin", "x86"),
         Path.Combine("bin", "win64")


### PR DESCRIPTION
Added a workaround for Witcher 3 preferring the x64 subfolder over the x64_dx12 subfolder. This is meant as a temporary "ugly" fix until we develop a proper solution.