### PR TITLE
Add comprehensive test coverage and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+  DOTNET_NOLOGO: "1"
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+          cache: true
+          cache-dependency-path: src/**/packages.lock.json
+
+      - name: Restore
+        run: dotnet restore Restall.slnx --locked-mode
+
+      - name: Build
+        run: dotnet build Restall.slnx --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test Restall.slnx --configuration Release --no-build --verbosity normal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - "**"
   pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: "1"
@@ -14,6 +22,7 @@ jobs:
   build-and-test:
     name: Build and test
     runs-on: windows-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout

--- a/Restall.slnx
+++ b/Restall.slnx
@@ -2,5 +2,6 @@
   <Project Path="src/Restall.Application/Restall.Application.csproj" />
   <Project Path="src/Restall.Domain/Restall.Domain.csproj" />
   <Project Path="src/Restall.Infrastructure/Restall.Infrastructure.csproj" />
+  <Project Path="src/Restall.Tests/Restall.Tests.csproj" />
   <Project Path="src/Restall.UI/Restall.UI.csproj" />
 </Solution>

--- a/src/Restall.Infrastructure/Properties/AssemblyInfo.cs
+++ b/src/Restall.Infrastructure/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Restall.Tests")]

--- a/src/Restall.Infrastructure/Services/FileExtractionService.cs
+++ b/src/Restall.Infrastructure/Services/FileExtractionService.cs
@@ -6,10 +6,17 @@ namespace Restall.Infrastructure.Services;
 internal sealed class FileExtractionService : IFileExtractionService
 {
     private readonly ILogService _logService;
+    private readonly IExtractionProcessRunner _processRunner;
 
     public FileExtractionService(ILogService logService)
+        : this(logService, new DefaultExtractionProcessRunner())
+    {
+    }
+
+    internal FileExtractionService(ILogService logService, IExtractionProcessRunner processRunner)
     {
         _logService = logService;
+        _processRunner = processRunner;
     }
 
     public bool ExtractFiles(string fileToOpen, string[] filesToExtract, string destinationPath)
@@ -42,20 +49,17 @@ internal sealed class FileExtractionService : IFileExtractionService
 
         try
         {
-            using var process = Process.Start(startInfo);
-            if (process == null)
+            var result = _processRunner.Run(startInfo);
+            if (result is null)
             {
                 _logService.LogInfo("Unable to start extraction process.");
                 return false;
             }
 
-            process.WaitForExit();
-
-            if (process.ExitCode != 0)
+            if (result.ExitCode != 0)
             {
-                var stderr = process.StandardError.ReadToEnd();
                 _logService.LogError($"Extraction failed with exit code " +
-                                               $"{process.ExitCode}: {stderr}");
+                                               $"{result.ExitCode}: {result.StandardError}");
                 return false;
             }
 
@@ -84,21 +88,22 @@ internal sealed class FileExtractionService : IFileExtractionService
     {
         try
         {
-            var process = Process.Start(new ProcessStartInfo
+            var processInfo = new ProcessStartInfo
             {
                 FileName = finder,
                 Arguments = tool,
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardOutput = true
-            });
+            };
 
-            if (process == null) return null;
+            var result = _processRunner.Run(processInfo);
 
-            var output = process.StandardOutput.ReadToEnd().Trim();
-            process.WaitForExit();
+            if (result == null) return null;
 
-            if (process.ExitCode == 0 && !string.IsNullOrWhiteSpace(output))
+            var output = result.StandardOutput.Trim();
+
+            if (result.ExitCode == 0 && !string.IsNullOrWhiteSpace(output))
                 return output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)[0].Trim();
         }
         catch (Exception ex)
@@ -107,5 +112,32 @@ internal sealed class FileExtractionService : IFileExtractionService
         }
 
         return null;
+    }
+}
+
+internal interface IExtractionProcessRunner
+{
+    ExtractionProcessResult? Run(ProcessStartInfo startInfo);
+}
+
+internal sealed record ExtractionProcessResult(int ExitCode, string StandardOutput, string StandardError);
+
+internal sealed class DefaultExtractionProcessRunner : IExtractionProcessRunner
+{
+    public ExtractionProcessResult? Run(ProcessStartInfo startInfo)
+    {
+        using var process = Process.Start(startInfo);
+        if (process == null) return null;
+
+        process.WaitForExit();
+
+        var stdout = startInfo.RedirectStandardOutput
+            ? process.StandardOutput.ReadToEnd()
+            : string.Empty;
+        var stderr = startInfo.RedirectStandardError
+            ? process.StandardError.ReadToEnd()
+            : string.Empty;
+
+        return new ExtractionProcessResult(process.ExitCode, stdout, stderr);
     }
 }

--- a/src/Restall.Tests/Application/GameNameHelperTests.cs
+++ b/src/Restall.Tests/Application/GameNameHelperTests.cs
@@ -1,0 +1,78 @@
+using Restall.Application.Helpers;
+
+namespace Restall.Tests.Application;
+
+public sealed class GameNameHelperTests
+{
+    // Verifies that normalization trims, lowercases, and removes punctuation from game names.
+    [Theory]
+    [InlineData("  Cyberpunk 2077: Ultimate Edition!  ", "cyberpunk 2077 ultimate edition")]
+    [InlineData("Baldur's Gate 3", "baldurs gate 3")]
+    [InlineData("FINAL-FANTASY VII", "finalfantasy vii")]
+    public void NormalizeName_RemovesPunctuationAndNormalizesCasing(string input, string expected)
+    {
+        var result = GameNameHelper.NormalizeName(input);
+
+        Assert.Equal(expected, result);
+    }
+
+    // Verifies that blank game names normalize to an empty string.
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void NormalizeName_WhenInputIsBlank_ReturnsEmptyString(string? input)
+    {
+        var result = GameNameHelper.NormalizeName(input!);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    // Verifies that common edition suffixes are stripped from game names.
+    [Theory]
+    [InlineData("Control Deluxe Edition", "Control")]
+    [InlineData("The Witcher 3 GOTY", "The Witcher 3")]
+    [InlineData("Elden Ring Game of the Year", "Elden Ring")]
+    [InlineData("Alan Wake Remastered", "Alan Wake")]
+    public void StripEditionSuffix_RemovesKnownEditionSuffixes(string input, string expected)
+    {
+        var result = GameNameHelper.StripEditionSuffix(input);
+
+        Assert.Equal(expected, result);
+    }
+
+    // Verifies that names without edition suffixes are not changed.
+    [Theory]
+    [InlineData("Hades")]
+    [InlineData("Control Bureau")]
+    public void StripEditionSuffix_WhenNoMatchingSuffixExists_ReturnsOriginalName(string input)
+    {
+        var result = GameNameHelper.StripEditionSuffix(input);
+
+        Assert.Equal(input, result);
+    }
+
+    // Verifies that fuzzy matching accepts close name variants with shared word coverage.
+    [Theory]
+    [InlineData("the witcher 3 wild hunt", "witcher 3")]
+    [InlineData("resident evil village", "resident evil")]
+    [InlineData("final fantasy vii remake", "final fantasy vii")]
+    public void FuzzyNameMatch_WhenNamesShareEnoughWords_ReturnsTrue(string a, string b)
+    {
+        var result = GameNameHelper.FuzzyNameMatch(a, b);
+
+        Assert.True(result);
+    }
+
+    // Verifies that fuzzy matching rejects unrelated or too-weak name matches.
+    [Theory]
+    [InlineData("hades", "doom eternal")]
+    [InlineData("star", "starfield")]
+    [InlineData("resident evil", "village")]
+    public void FuzzyNameMatch_WhenNamesAreUnrelatedOrTooWeak_ReturnsFalse(string a, string b)
+    {
+        var result = GameNameHelper.FuzzyNameMatch(a, b);
+
+        Assert.False(result);
+    }
+}

--- a/src/Restall.Tests/Application/InstallReShadeUseCaseTests.cs
+++ b/src/Restall.Tests/Application/InstallReShadeUseCaseTests.cs
@@ -1,0 +1,209 @@
+using Moq;
+using Restall.Application.DTOs;
+using Restall.Application.Interfaces.Driven;
+using Restall.Application.UseCases;
+using Restall.Application.UseCases.Requests;
+using Restall.Domain.Entities;
+using Restall.Tests.TestUtilities;
+
+namespace Restall.Tests.Application;
+
+public sealed class InstallReShadeUseCaseTests
+{
+    // Verifies that cached extracted ReShade files are installed without download or extraction.
+    [Fact]
+    public async Task ExecuteAsync_WhenExtractedFileExists_InstallsWithoutDownloadOrExtract()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var request = CreateRequest();
+        var extractedPath = temp.CreateFile(Path.Combine("cache", "ReShade64.dll"), "reshade");
+        context.PathService.Setup(x => x.GetReShadeExtractedFilePath(It.IsAny<ReShade>())).Returns(extractedPath);
+        context.ModInstall.Setup(x => x.InstallModAsync(request.Game, It.IsAny<ReShade>(), extractedPath))
+            .ReturnsAsync((Game game, ReShade reShade, string _) =>
+            {
+                game.ReShade = reShade;
+                return new ModOperationResultDto(true, game);
+            });
+
+        var result = await context.Sut.ExecuteAsync(request);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(request.SelectedFilename, result.UpdatedGame.ReShade?.SelectedFilename);
+        context.ModDownload.Verify(x => x.DownloadReShadeAsync(
+            It.IsAny<ReShade.Branch>(),
+            It.IsAny<string>(),
+            It.IsAny<IProgress<DownloadProgressReportDto>?>()), Times.Never);
+        context.FileExtraction.Verify(x => x.ExtractFiles(
+            It.IsAny<string>(),
+            It.IsAny<string[]>(),
+            It.IsAny<string>()), Times.Never);
+    }
+
+    // Verifies that cached installers skip download but still extract and install when extracted files are missing.
+    [Fact]
+    public async Task ExecuteAsync_WhenInstallerExistsButExtractedFileIsMissing_ExtractsAndInstalls()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var request = CreateRequest();
+        var installerPath = temp.CreateFile(Path.Combine("downloads", "ReShade_Setup_6.5.0_Addon.exe"), "installer");
+        var extractedPath = temp.GetPath("cache", "Stable", "6.5.0", "ReShade64.dll");
+        var extractionDir = Path.GetDirectoryName(extractedPath)!;
+
+        context.PathService.Setup(x => x.GetReShadeExtractedFilePath(It.IsAny<ReShade>())).Returns(extractedPath);
+        context.PathService.Setup(x => x.GetReShadeInstallerFilePath(ReShade.Branch.Stable, "6.5.0")).Returns(installerPath);
+        context.PathService.Setup(x => x.GetReShadeCachePath(It.IsAny<ReShade>())).Returns(extractionDir);
+        context.FileExtraction.Setup(x => x.ExtractFiles(
+                installerPath,
+                It.Is<string[]>(files => files.SequenceEqual(new[] { "ReShade64.dll" })),
+                extractionDir))
+            .Returns(true);
+        context.ModInstall.Setup(x => x.InstallModAsync(request.Game, It.IsAny<ReShade>(), extractedPath))
+            .ReturnsAsync(new ModOperationResultDto(true, request.Game));
+
+        var result = await context.Sut.ExecuteAsync(request);
+
+        Assert.True(result.IsSuccess);
+        context.ModDownload.Verify(x => x.DownloadReShadeAsync(
+            It.IsAny<ReShade.Branch>(),
+            It.IsAny<string>(),
+            It.IsAny<IProgress<DownloadProgressReportDto>?>()), Times.Never);
+        context.FileExtraction.VerifyAll();
+        context.ModInstall.Verify(x => x.InstallModAsync(request.Game, It.IsAny<ReShade>(), extractedPath), Times.Once);
+    }
+
+    // Verifies that failed ReShade downloads stop before extraction and installation.
+    [Fact]
+    public async Task ExecuteAsync_WhenDownloadFails_ReturnsFailureWithoutExtractOrInstall()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var request = CreateRequest();
+        context.PathService.Setup(x => x.GetReShadeExtractedFilePath(It.IsAny<ReShade>()))
+            .Returns(temp.GetPath("cache", "ReShade64.dll"));
+        context.PathService.Setup(x => x.GetReShadeInstallerFilePath(ReShade.Branch.Stable, "6.5.0"))
+            .Returns(temp.GetPath("downloads", "ReShade_Setup_6.5.0_Addon.exe"));
+        context.ModDownload.Setup(x => x.DownloadReShadeAsync(
+                ReShade.Branch.Stable,
+                "6.5.0",
+                It.IsAny<IProgress<DownloadProgressReportDto>?>()))
+            .ReturnsAsync(false);
+
+        var result = await context.Sut.ExecuteAsync(request);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Failed to download ReShade installer.", result.Message);
+        context.FileExtraction.Verify(x => x.ExtractFiles(It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<string>()), Times.Never);
+        context.ModInstall.Verify(x => x.InstallModAsync(It.IsAny<Game>(), It.IsAny<ReShade>(), It.IsAny<string>()), Times.Never);
+    }
+
+    // Verifies that failed ReShade extraction stops before installation.
+    [Fact]
+    public async Task ExecuteAsync_WhenExtractionFails_ReturnsFailureWithoutInstall()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var request = CreateRequest();
+        var installerPath = temp.GetPath("downloads", "ReShade_Setup_6.5.0_Addon.exe");
+        var extractionDir = temp.GetPath("cache", "Stable", "6.5.0");
+
+        context.PathService.Setup(x => x.GetReShadeExtractedFilePath(It.IsAny<ReShade>()))
+            .Returns(Path.Combine(extractionDir, "ReShade64.dll"));
+        context.PathService.Setup(x => x.GetReShadeInstallerFilePath(ReShade.Branch.Stable, "6.5.0")).Returns(installerPath);
+        context.PathService.Setup(x => x.GetReShadeCachePath(It.IsAny<ReShade>())).Returns(extractionDir);
+        context.ModDownload.Setup(x => x.DownloadReShadeAsync(
+                ReShade.Branch.Stable,
+                "6.5.0",
+                It.IsAny<IProgress<DownloadProgressReportDto>?>()))
+            .ReturnsAsync(true);
+        context.FileExtraction.Setup(x => x.ExtractFiles(installerPath, It.IsAny<string[]>(), extractionDir)).Returns(false);
+
+        var result = await context.Sut.ExecuteAsync(request);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Failed to extract files from installer.", result.Message);
+        context.ModInstall.Verify(x => x.InstallModAsync(It.IsAny<Game>(), It.IsAny<ReShade>(), It.IsAny<string>()), Times.Never);
+    }
+
+    // Verifies that install failures are returned after a valid ReShade package is prepared.
+    [Fact]
+    public async Task ExecuteAsync_WhenInstallFails_ReturnsInstallResult()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var request = CreateRequest();
+        var extractedPath = temp.CreateFile(Path.Combine("cache", "ReShade64.dll"), "reshade");
+        var expected = new ModOperationResultDto(false, request.Game, "install failed");
+
+        context.PathService.Setup(x => x.GetReShadeExtractedFilePath(It.IsAny<ReShade>())).Returns(extractedPath);
+        context.ModInstall.Setup(x => x.InstallModAsync(request.Game, It.IsAny<ReShade>(), extractedPath))
+            .ReturnsAsync(expected);
+
+        var result = await context.Sut.ExecuteAsync(request);
+
+        Assert.Same(expected, result);
+    }
+
+    // Verifies that request data is mapped onto the ReShade model passed to the installer.
+    [Fact]
+    public async Task ExecuteAsync_MapsRequestDataToInstalledReShade()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var request = new InstallReShadeRequest(
+            new Game { Name = "Test Game" },
+            ReShade.Branch.Nightly,
+            ReShade.Architecture.x32,
+            "6.4.1",
+            "d3d9.asi");
+        var extractedPath = temp.CreateFile(Path.Combine("cache", "ReShade32.dll"), "reshade");
+        ReShade? captured = null;
+
+        context.PathService.Setup(x => x.GetReShadeExtractedFilePath(It.IsAny<ReShade>())).Returns(extractedPath);
+        context.ModInstall.Setup(x => x.InstallModAsync(request.Game, It.IsAny<ReShade>(), extractedPath))
+            .Callback<Game, ReShade, string>((_, reShade, _) => captured = reShade)
+            .ReturnsAsync(new ModOperationResultDto(true, request.Game));
+
+        await context.Sut.ExecuteAsync(request);
+
+        Assert.NotNull(captured);
+        Assert.Equal(ReShade.Branch.Nightly, captured.BranchName);
+        Assert.Equal(ReShade.Architecture.x32, captured.Arch);
+        Assert.Equal("6.4.1", captured.Version);
+        Assert.Equal("d3d9.asi", captured.SelectedFilename);
+    }
+
+    private static InstallReShadeRequest CreateRequest() =>
+        new(new Game { Name = "Test Game" }, ReShade.Branch.Stable, ReShade.Architecture.x64, "6.5.0", "dxgi.dll");
+
+    private static ReShadeContext CreateContext(TempDirectory temp)
+    {
+        var pathService = new Mock<IPathService>(MockBehavior.Strict);
+        var modDownload = new Mock<IModDownloadService>(MockBehavior.Strict);
+        var fileExtraction = new Mock<IFileExtractionService>(MockBehavior.Strict);
+        var modInstall = new Mock<IModInstallService>(MockBehavior.Strict);
+
+        pathService.Setup(x => x.GetReShadeInstallerFilePath(It.IsAny<ReShade.Branch>(), It.IsAny<string>()))
+            .Returns((ReShade.Branch branch, string version) =>
+                temp.GetPath("downloads", branch.ToString(), $"ReShade_Setup_{version}_Addon.exe"));
+        pathService.Setup(x => x.GetReShadeCachePath(It.IsAny<ReShade>()))
+            .Returns((ReShade reShade) => temp.GetPath("cache", reShade.BranchName.ToString(), reShade.Version!));
+
+        var sut = new InstallReShadeUseCase(
+            pathService.Object,
+            modDownload.Object,
+            fileExtraction.Object,
+            modInstall.Object,
+            new NoOpLogService());
+
+        return new ReShadeContext(sut, pathService, modDownload, fileExtraction, modInstall);
+    }
+
+    private sealed record ReShadeContext(
+        InstallReShadeUseCase Sut,
+        Mock<IPathService> PathService,
+        Mock<IModDownloadService> ModDownload,
+        Mock<IFileExtractionService> FileExtraction,
+        Mock<IModInstallService> ModInstall);
+}

--- a/src/Restall.Tests/Application/InstallRenoDXUseCaseTests.cs
+++ b/src/Restall.Tests/Application/InstallRenoDXUseCaseTests.cs
@@ -1,0 +1,318 @@
+using Moq;
+using Restall.Application.DTOs;
+using Restall.Application.Interfaces.Driven;
+using Restall.Application.UseCases;
+using Restall.Application.UseCases.Requests;
+using Restall.Domain.Entities;
+using Restall.Tests.TestUtilities;
+
+namespace Restall.Tests.Application;
+
+public sealed class InstallRenoDXUseCaseTests
+{
+    // Verifies that x64 wiki mods use the x64 addon URL and filename.
+    [Fact]
+    public async Task ExecuteAsync_WhenSpecificWikiModSupportsX64_InstallsX64Addon()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var mod = CreateSpecificMod(snapshot64: "https://example.test/renodx-game.addon64");
+        var request = CreateRequest(RenoDX.Architecture.x64, RenoDX.Branch.Wiki, modInfo: mod);
+
+        var captured = await ExecuteSuccessfulInstallAsync(context, request);
+
+        Assert.Equal("renodx-game.addon64", captured.OriginalName);
+        Assert.Equal("renodx-game.addon64", captured.SelectedName);
+        context.ModDownload.Verify(x => x.DownloadRenoDXAsync(
+            RenoDX.Branch.Wiki,
+            "renodx-game.addon64",
+            null,
+            "https://example.test/renodx-game.addon64",
+            It.IsAny<IProgress<DownloadProgressReportDto>?>()), Times.Once);
+    }
+
+    // Verifies that x32 wiki installs fall back to x64 when no x32 addon exists.
+    [Fact]
+    public async Task ExecuteAsync_WhenSpecificWikiModLacksX32_FallsBackToX64Addon()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var mod = CreateSpecificMod(snapshot64: "https://example.test/renodx-game.addon64");
+        var request = CreateRequest(RenoDX.Architecture.x32, RenoDX.Branch.Wiki, modInfo: mod);
+
+        var captured = await ExecuteSuccessfulInstallAsync(context, request);
+
+        Assert.Equal("renodx-game.addon64", captured.OriginalName);
+        context.ModDownload.Verify(x => x.DownloadRenoDXAsync(
+            RenoDX.Branch.Wiki,
+            "renodx-game.addon64",
+            null,
+            null,
+            It.IsAny<IProgress<DownloadProgressReportDto>?>()), Times.Once);
+    }
+
+    // Verifies that generic Unreal mods resolve to Unreal addon names for the requested architecture.
+    [Theory]
+    [InlineData(RenoDX.Architecture.x64, "renodx-unrealengine.addon64")]
+    [InlineData(RenoDX.Architecture.x32, "renodx-unrealengine.addon32")]
+    public async Task ExecuteAsync_WhenGenericUnrealModIsUsed_InstallsUnrealAddon(
+        RenoDX.Architecture architecture,
+        string expectedAddon)
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var generic = new RenoDXGenericModInfoDto("Generic Unreal", ":white_check_mark:", SupportedEngine.Unreal);
+        var request = CreateRequest(architecture, RenoDX.Branch.Snapshot, genericModInfo: generic);
+
+        var captured = await ExecuteSuccessfulInstallAsync(context, request);
+
+        Assert.Equal(expectedAddon, captured.OriginalName);
+        Assert.Equal(RenoDX.Branch.Snapshot, captured.BranchName);
+        context.ModDownload.Verify(x => x.DownloadRenoDXAsync(
+            RenoDX.Branch.Snapshot,
+            expectedAddon,
+            null,
+            null,
+            It.IsAny<IProgress<DownloadProgressReportDto>?>()), Times.Once);
+    }
+
+    // Verifies that generic Unity mods use the Unity download path and force Snapshot branch.
+    [Fact]
+    public async Task ExecuteAsync_WhenGenericUnityModIsUsed_UsesUnityDownloadAndSnapshotBranch()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var generic = new RenoDXGenericModInfoDto("Generic Unity", ":white_check_mark:", SupportedEngine.Unity);
+        var request = CreateRequest(RenoDX.Architecture.x64, RenoDX.Branch.Nightly, genericModInfo: generic);
+
+        var captured = await ExecuteSuccessfulInstallAsync(context, request);
+
+        Assert.Equal("renodx-unityengine.addon64", captured.OriginalName);
+        Assert.Equal(RenoDX.Branch.Snapshot, captured.BranchName);
+        context.ModDownload.Verify(x => x.DownloadUnityRenoDXAsync(
+            "renodx-unityengine.addon64",
+            It.IsAny<IProgress<DownloadProgressReportDto>?>()), Times.Once);
+        context.ModDownload.Verify(x => x.DownloadRenoDXAsync(
+            It.IsAny<RenoDX.Branch>(),
+            It.IsAny<string?>(),
+            It.IsAny<string?>(),
+            It.IsAny<string?>(),
+            It.IsAny<IProgress<DownloadProgressReportDto>?>()), Times.Never);
+    }
+
+    // Verifies that Unity and Unreal engine names are used when no wiki or generic mod is provided.
+    [Theory]
+    [InlineData(Game.Engine.Unity, RenoDX.Architecture.x64, "renodx-unityengine.addon64")]
+    [InlineData(Game.Engine.Unreal, RenoDX.Architecture.x32, "renodx-unrealengine.addon32")]
+    public async Task ExecuteAsync_WhenOnlyGameEngineIsKnown_UsesEngineBasedAddon(
+        Game.Engine engine,
+        RenoDX.Architecture architecture,
+        string expectedAddon)
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var request = CreateRequest(architecture, RenoDX.Branch.Snapshot);
+        request.Game.EngineName = engine;
+
+        var captured = await ExecuteSuccessfulInstallAsync(context, request);
+
+        Assert.Equal(expectedAddon, captured.OriginalName);
+    }
+
+    // Verifies that unknown games without mod metadata fail before download or install.
+    [Fact]
+    public async Task ExecuteAsync_WhenAddonFilenameCannotBeResolved_ReturnsFailureWithoutDownloadOrInstall()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var request = CreateRequest(RenoDX.Architecture.x64, RenoDX.Branch.Snapshot);
+
+        var result = await context.Sut.ExecuteAsync(request);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("Could not determine addon filename", result.Message);
+        context.ModDownload.Verify(x => x.DownloadRenoDXAsync(
+            It.IsAny<RenoDX.Branch>(),
+            It.IsAny<string?>(),
+            It.IsAny<string?>(),
+            It.IsAny<string?>(),
+            It.IsAny<IProgress<DownloadProgressReportDto>?>()), Times.Never);
+        context.ModDownload.Verify(x => x.DownloadUnityRenoDXAsync(
+            It.IsAny<string>(),
+            It.IsAny<IProgress<DownloadProgressReportDto>?>()), Times.Never);
+        context.ModInstall.Verify(x => x.InstallModAsync(It.IsAny<Game>(), It.IsAny<RenoDX>(), It.IsAny<string>()), Times.Never);
+    }
+
+    // Verifies that reinstalling RenoDX keeps the previously selected filename.
+    [Fact]
+    public async Task ExecuteAsync_WhenGameAlreadyHasRenoDX_KeepsExistingSelectedName()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var mod = CreateSpecificMod(snapshot64: "https://example.test/renodx-game.addon64");
+        var request = CreateRequest(RenoDX.Architecture.x64, RenoDX.Branch.Wiki, modInfo: mod);
+        request.Game.RenoDX = new RenoDX
+        {
+            OriginalName = "renodx-game.addon64",
+            SelectedName = "custom-renodx.addon64"
+        };
+
+        var captured = await ExecuteSuccessfulInstallAsync(context, request);
+
+        Assert.Equal("renodx-game.addon64", captured.OriginalName);
+        Assert.Equal("custom-renodx.addon64", captured.SelectedName);
+    }
+
+    // Verifies that outdated RenoDX cache files are deleted before download.
+    [Fact]
+    public async Task ExecuteAsync_WhenCachedVersionDiffersFromTarget_DeletesCachedFile()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var mod = CreateSpecificMod(snapshot64: "https://example.test/renodx-game.addon64");
+        var request = CreateRequest(RenoDX.Architecture.x64, RenoDX.Branch.Snapshot, modInfo: mod, targetVersion: "20240202");
+        var cachePath = temp.CreateFile(Path.Combine("renodx-cache", "Snapshot", "renodx-game.addon64"), "cached");
+        context.ModDetection.SetupSequence(x => x.GetRenoDXFileVersion(cachePath))
+            .Returns("20240101")
+            .Returns("20240202");
+
+        await ExecuteSuccessfulInstallAsync(context, request, setupDefaultVersionDetection: false);
+
+        Assert.False(File.Exists(cachePath));
+    }
+
+    // Verifies that RenoDX cache files are kept when target version is absent, invalid, or already current.
+    [Theory]
+    [InlineData(null, "20240101")]
+    [InlineData("not-a-date", "20240101")]
+    [InlineData("20240101", "20240101")]
+    public async Task ExecuteAsync_WhenCacheInvalidationIsNotRequired_KeepsCachedFile(
+        string? targetVersion,
+        string cachedVersion)
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var mod = CreateSpecificMod(snapshot64: "https://example.test/renodx-game.addon64");
+        var request = CreateRequest(RenoDX.Architecture.x64, RenoDX.Branch.Snapshot, modInfo: mod, targetVersion: targetVersion);
+        var cachePath = temp.CreateFile(Path.Combine("renodx-cache", "Snapshot", "renodx-game.addon64"), "cached");
+        context.ModDetection.SetupSequence(x => x.GetRenoDXFileVersion(cachePath))
+            .Returns(cachedVersion)
+            .Returns(cachedVersion);
+
+        await ExecuteSuccessfulInstallAsync(context, request, setupDefaultVersionDetection: false);
+
+        Assert.True(File.Exists(cachePath));
+    }
+
+    // Verifies that failed RenoDX downloads stop version detection and installation.
+    [Fact]
+    public async Task ExecuteAsync_WhenDownloadFails_ReturnsFailureWithoutDetectingVersionOrInstalling()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext(temp);
+        var mod = CreateSpecificMod(snapshot64: "https://example.test/renodx-game.addon64");
+        var request = CreateRequest(RenoDX.Architecture.x64, RenoDX.Branch.Snapshot, modInfo: mod);
+
+        context.ModDownload.Setup(x => x.DownloadRenoDXAsync(
+                RenoDX.Branch.Snapshot,
+                "renodx-game.addon64",
+                null,
+                "https://example.test/renodx-game.addon64",
+                It.IsAny<IProgress<DownloadProgressReportDto>?>()))
+            .ReturnsAsync(false);
+
+        var result = await context.Sut.ExecuteAsync(request);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Failed to download file.", result.Message);
+        context.ModDetection.Verify(x => x.GetRenoDXFileVersion(It.IsAny<string>()), Times.Never);
+        context.ModInstall.Verify(x => x.InstallModAsync(It.IsAny<Game>(), It.IsAny<RenoDX>(), It.IsAny<string>()), Times.Never);
+    }
+
+    private static async Task<RenoDX> ExecuteSuccessfulInstallAsync(
+        RenoDXContext context,
+        InstallRenoDXRequest request,
+        bool setupDefaultVersionDetection = true)
+    {
+        RenoDX? captured = null;
+
+        context.ModDownload.Setup(x => x.DownloadRenoDXAsync(
+                It.IsAny<RenoDX.Branch>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<IProgress<DownloadProgressReportDto>?>()))
+            .ReturnsAsync(true);
+        context.ModDownload.Setup(x => x.DownloadUnityRenoDXAsync(
+                It.IsAny<string>(),
+                It.IsAny<IProgress<DownloadProgressReportDto>?>()))
+            .ReturnsAsync(true);
+        if (setupDefaultVersionDetection)
+            context.ModDetection.Setup(x => x.GetRenoDXFileVersion(It.IsAny<string>())).Returns("20240202");
+        context.ModInstall.Setup(x => x.InstallModAsync(request.Game, It.IsAny<RenoDX>(), It.IsAny<string>()))
+            .Callback<Game, RenoDX, string>((_, renoDX, _) => captured = renoDX)
+            .ReturnsAsync((Game game, RenoDX renoDX, string _) =>
+            {
+                game.RenoDX = renoDX;
+                return new ModOperationResultDto(true, game);
+            });
+
+        var result = await context.Sut.ExecuteAsync(request);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(captured);
+        return captured;
+    }
+
+    private static InstallRenoDXRequest CreateRequest(
+        RenoDX.Architecture architecture,
+        RenoDX.Branch branch,
+        RenoDXModInfoDto? modInfo = null,
+        RenoDXGenericModInfoDto? genericModInfo = null,
+        string? targetVersion = null) =>
+        new(
+            new Game { Name = "Test Game", EngineName = Game.Engine.Unknown },
+            architecture,
+            branch,
+            modInfo,
+            genericModInfo,
+            targetVersion);
+
+    private static RenoDXModInfoDto CreateSpecificMod(string? snapshot64 = null, string? snapshot32 = null) =>
+        new(
+            "Test Game",
+            DiscordUrl: null,
+            SnapshotUrl64: snapshot64,
+            SnapshotUrl32: snapshot32,
+            NexusUrl: null,
+            Maintainer: "Maintainer",
+            Notes: null,
+            Status: ":white_check_mark:");
+
+    private static RenoDXContext CreateContext(TempDirectory temp)
+    {
+        var modDownload = new Mock<IModDownloadService>(MockBehavior.Strict);
+        var modInstall = new Mock<IModInstallService>(MockBehavior.Strict);
+        var modDetection = new Mock<IModDetectionService>(MockBehavior.Strict);
+        var pathService = new Mock<IPathService>(MockBehavior.Strict);
+
+        pathService.Setup(x => x.GetRenoDXCachePath(It.IsAny<RenoDX>()))
+            .Returns((RenoDX renoDX) => temp.GetPath("renodx-cache", renoDX.BranchName.ToString(), renoDX.OriginalName!));
+
+        var sut = new InstallRenoDXUseCase(
+            modDownload.Object,
+            modInstall.Object,
+            modDetection.Object,
+            pathService.Object,
+            new NoOpLogService());
+
+        return new RenoDXContext(sut, modDownload, modInstall, modDetection, pathService);
+    }
+
+    private sealed record RenoDXContext(
+        InstallRenoDXUseCase Sut,
+        Mock<IModDownloadService> ModDownload,
+        Mock<IModInstallService> ModInstall,
+        Mock<IModDetectionService> ModDetection,
+        Mock<IPathService> PathService);
+}

--- a/src/Restall.Tests/Application/ModManagementFacadeTests.cs
+++ b/src/Restall.Tests/Application/ModManagementFacadeTests.cs
@@ -1,0 +1,314 @@
+using Moq;
+using Restall.Application.DTOs;
+using Restall.Application.Facades;
+using Restall.Application.Interfaces.Driven;
+using Restall.Application.Interfaces.Driving;
+using Restall.Application.UseCases.Requests;
+using Restall.Domain.Entities;
+using Restall.Tests.TestUtilities;
+
+namespace Restall.Tests.Application;
+
+public sealed class ModManagementFacadeTests
+{
+    [Fact]
+    public async Task InstallOrUpdateReShadeAsync_WhenGameFolderIsMissing_ReturnsErrorWithoutCallingUseCase()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext();
+        var game = CreateGame(temp.GetPath("missing"));
+
+        var result = await context.Sut.InstallOrUpdateReShadeAsync(CreateReShadeRequest(game));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Game folder not found. Please rescan your library.", result.Message);
+        context.InstallReShade.Verify(
+            x => x.ExecuteAsync(It.IsAny<InstallReShadeRequest>(), It.IsAny<IProgress<DownloadProgressReportDto>?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task InstallOrUpdateReShadeAsync_WhenRecordedFileIsMissing_ReturnsStaleRecordError()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext();
+        var game = CreateGame(temp.CreateDirectory("game"));
+        game.ReShade = new ReShade { SelectedFilename = "dxgi.dll", Version = "6.4.0" };
+
+        var result = await context.Sut.InstallOrUpdateReShadeAsync(CreateReShadeRequest(game));
+
+        Assert.False(result.IsSuccess);
+        Assert.True(result.ShouldPromptForDeepScan);
+        Assert.Contains("dxgi.dll", result.Message);
+        context.InstallReShade.Verify(
+            x => x.ExecuteAsync(It.IsAny<InstallReShadeRequest>(), It.IsAny<IProgress<DownloadProgressReportDto>?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task InstallOrUpdateReShadeAsync_WhenInstallSucceeds_AddsUpdateCheckResult()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext();
+        var game = CreateGame(temp.CreateDirectory("game"));
+        var installed = new ReShade { SelectedFilename = "dxgi.dll", Version = "6.5.0" };
+        var updatedGame = CreateGame(game.ExecutablePath!);
+        updatedGame.ReShade = installed;
+        var updateResult = new UpdateCheckResultDto(false, "6.5.0", "6.5.0");
+
+        context.InstallReShade
+            .Setup(x => x.ExecuteAsync(
+                It.IsAny<InstallReShadeRequest>(),
+                It.IsAny<IProgress<DownloadProgressReportDto>?>()))
+            .ReturnsAsync(new ModOperationResultDto(true, updatedGame));
+        context.UpdateCheck.Setup(x => x.CheckReShadeUpdate(installed)).Returns(updateResult);
+
+        var result = await context.Sut.InstallOrUpdateReShadeAsync(CreateReShadeRequest(game));
+
+        Assert.True(result.IsSuccess);
+        Assert.Same(updateResult, result.UpdateCheckResult);
+        context.UpdateCheck.Verify(x => x.CheckReShadeUpdate(installed), Times.Once);
+    }
+
+    [Fact]
+    public async Task InstallOrUpdateReShadeAsync_WhenInstallFails_DoesNotRunUpdateCheck()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext();
+        var game = CreateGame(temp.CreateDirectory("game"));
+
+        context.InstallReShade
+            .Setup(x => x.ExecuteAsync(
+                It.IsAny<InstallReShadeRequest>(),
+                It.IsAny<IProgress<DownloadProgressReportDto>?>()))
+            .ReturnsAsync(new ModOperationResultDto(false, game, "failed"));
+
+        var result = await context.Sut.InstallOrUpdateReShadeAsync(CreateReShadeRequest(game));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("failed", result.Message);
+        context.UpdateCheck.Verify(x => x.CheckReShadeUpdate(It.IsAny<ReShade>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UninstallReShadeAsync_WhenGameFolderIsMissing_ReturnsErrorWithoutCallingUseCase()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext();
+        var game = CreateGame(temp.GetPath("missing"));
+        game.ReShade = new ReShade { SelectedFilename = "dxgi.dll" };
+
+        var result = await context.Sut.UninstallReShadeAsync(game);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Game folder not found. Please rescan your library.", result.Message);
+        context.UninstallReShade.Verify(x => x.ExecuteAsync(It.IsAny<Game>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UninstallReShadeAsync_WhenNoReShadeIsRecorded_ReturnsErrorWithoutCallingUseCase()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext();
+        var game = CreateGame(temp.CreateDirectory("game"));
+
+        var result = await context.Sut.UninstallReShadeAsync(game);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("No ReShade installation detected", result.Message);
+        context.UninstallReShade.Verify(x => x.ExecuteAsync(It.IsAny<Game>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UninstallReShadeAsync_WhenReShadeIsRecorded_CallsUseCase()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext();
+        var game = CreateGame(temp.CreateDirectory("game"));
+        game.ReShade = new ReShade { SelectedFilename = "dxgi.dll" };
+        var expected = new ModOperationResultDto(true, game, "ok");
+
+        context.UninstallReShade.Setup(x => x.ExecuteAsync(game)).ReturnsAsync(expected);
+
+        var result = await context.Sut.UninstallReShadeAsync(game);
+
+        Assert.Same(expected, result);
+        context.UninstallReShade.Verify(x => x.ExecuteAsync(game), Times.Once);
+    }
+
+    [Fact]
+    public async Task InstallOrUpdateRenoDXAsync_WhenGameFolderIsMissing_ReturnsErrorWithoutCallingUseCase()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext();
+        var game = CreateGame(temp.GetPath("missing"));
+
+        var result = await context.Sut.InstallOrUpdateRenoDXAsync(CreateRenoDXRequest(game));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Game folder not found. Please rescan your library.", result.Message);
+        context.InstallRenoDX.Verify(
+            x => x.ExecuteAsync(It.IsAny<InstallRenoDXRequest>(), It.IsAny<IProgress<DownloadProgressReportDto>?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task InstallOrUpdateRenoDXAsync_WhenRecordedFileIsMissing_ReturnsStaleRecordError()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext();
+        var game = CreateGame(temp.CreateDirectory("game"));
+        game.RenoDX = new RenoDX { SelectedName = "renodx-game.addon64", Version = "20240101" };
+
+        var result = await context.Sut.InstallOrUpdateRenoDXAsync(CreateRenoDXRequest(game));
+
+        Assert.False(result.IsSuccess);
+        Assert.True(result.ShouldPromptForDeepScan);
+        Assert.Contains("renodx-game.addon64", result.Message);
+        context.InstallRenoDX.Verify(
+            x => x.ExecuteAsync(It.IsAny<InstallRenoDXRequest>(), It.IsAny<IProgress<DownloadProgressReportDto>?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task InstallOrUpdateRenoDXAsync_WhenInstallSucceeds_AddsUpdateCheckResult()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext();
+        var game = CreateGame(temp.CreateDirectory("game"));
+        var installed = new RenoDX
+        {
+            SelectedName = "renodx-game.addon64",
+            OriginalName = "renodx-game.addon64",
+            BranchName = RenoDX.Branch.Snapshot,
+            Version = "20240101"
+        };
+        var updatedGame = CreateGame(game.ExecutablePath!);
+        updatedGame.RenoDX = installed;
+        var updateResult = new UpdateCheckResultDto(true, "20240101", "20240202");
+
+        context.InstallRenoDX
+            .Setup(x => x.ExecuteAsync(
+                It.IsAny<InstallRenoDXRequest>(),
+                It.IsAny<IProgress<DownloadProgressReportDto>?>()))
+            .ReturnsAsync(new ModOperationResultDto(true, updatedGame));
+        context.UpdateCheck.Setup(x => x.CheckRenoDXUpdate(installed)).Returns(updateResult);
+
+        var result = await context.Sut.InstallOrUpdateRenoDXAsync(CreateRenoDXRequest(game));
+
+        Assert.True(result.IsSuccess);
+        Assert.Same(updateResult, result.UpdateCheckResult);
+        context.UpdateCheck.Verify(x => x.CheckRenoDXUpdate(installed), Times.Once);
+    }
+
+    [Fact]
+    public async Task InstallOrUpdateRenoDXAsync_WhenInstallFails_DoesNotRunUpdateCheck()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext();
+        var game = CreateGame(temp.CreateDirectory("game"));
+
+        context.InstallRenoDX
+            .Setup(x => x.ExecuteAsync(
+                It.IsAny<InstallRenoDXRequest>(),
+                It.IsAny<IProgress<DownloadProgressReportDto>?>()))
+            .ReturnsAsync(new ModOperationResultDto(false, game, "failed"));
+
+        var result = await context.Sut.InstallOrUpdateRenoDXAsync(CreateRenoDXRequest(game));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("failed", result.Message);
+        context.UpdateCheck.Verify(x => x.CheckRenoDXUpdate(It.IsAny<RenoDX>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UninstallRenoDXAsync_WhenGameFolderIsMissing_ReturnsErrorWithoutCallingUseCase()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext();
+        var game = CreateGame(temp.GetPath("missing"));
+        game.RenoDX = new RenoDX { SelectedName = "renodx-game.addon64" };
+
+        var result = await context.Sut.UninstallRenoDXAsync(game);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Game folder not found. Please rescan your library.", result.Message);
+        context.UninstallRenoDX.Verify(x => x.ExecuteAsync(It.IsAny<Game>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UninstallRenoDXAsync_WhenNoRenoDXIsRecorded_ReturnsErrorWithoutCallingUseCase()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext();
+        var game = CreateGame(temp.CreateDirectory("game"));
+
+        var result = await context.Sut.UninstallRenoDXAsync(game);
+
+        Assert.False(result.IsSuccess);
+        Assert.Contains("No RenoDX installation detected", result.Message);
+        context.UninstallRenoDX.Verify(x => x.ExecuteAsync(It.IsAny<Game>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UninstallRenoDXAsync_WhenRenoDXIsRecorded_CallsUseCase()
+    {
+        using var temp = new TempDirectory();
+        var context = CreateContext();
+        var game = CreateGame(temp.CreateDirectory("game"));
+        game.RenoDX = new RenoDX { SelectedName = "renodx-game.addon64" };
+        var expected = new ModOperationResultDto(true, game, "ok");
+
+        context.UninstallRenoDX.Setup(x => x.ExecuteAsync(game)).ReturnsAsync(expected);
+
+        var result = await context.Sut.UninstallRenoDXAsync(game);
+
+        Assert.Same(expected, result);
+        context.UninstallRenoDX.Verify(x => x.ExecuteAsync(game), Times.Once);
+    }
+
+    private static Game CreateGame(string executablePath) =>
+        new()
+        {
+            Name = "Test Game",
+            ExecutablePath = executablePath
+        };
+
+    private static InstallReShadeRequest CreateReShadeRequest(Game game) =>
+        new(game, ReShade.Branch.Stable, ReShade.Architecture.x64, "6.5.0", "dxgi.dll");
+
+    private static InstallRenoDXRequest CreateRenoDXRequest(Game game) =>
+        new(game, RenoDX.Architecture.x64, RenoDX.Branch.Snapshot);
+
+    private static FacadeContext CreateContext()
+    {
+        var installReShade = new Mock<IInstallReShadeUseCase>(MockBehavior.Strict);
+        var uninstallReShade = new Mock<IUninstallReShadeUseCase>(MockBehavior.Strict);
+        var installRenoDX = new Mock<IInstallRenoDXUseCase>(MockBehavior.Strict);
+        var uninstallRenoDX = new Mock<IUninstallRenoDXUseCase>(MockBehavior.Strict);
+        var updateCheck = new Mock<IUpdateCheckService>(MockBehavior.Strict);
+
+        var sut = new ModManagementFacade(
+            installReShade.Object,
+            uninstallReShade.Object,
+            installRenoDX.Object,
+            uninstallRenoDX.Object,
+            updateCheck.Object);
+
+        return new FacadeContext(
+            sut,
+            installReShade,
+            uninstallReShade,
+            installRenoDX,
+            uninstallRenoDX,
+            updateCheck);
+    }
+
+    private sealed record FacadeContext(
+        ModManagementFacade Sut,
+        Mock<IInstallReShadeUseCase> InstallReShade,
+        Mock<IUninstallReShadeUseCase> UninstallReShade,
+        Mock<IInstallRenoDXUseCase> InstallRenoDX,
+        Mock<IUninstallRenoDXUseCase> UninstallRenoDX,
+        Mock<IUpdateCheckService> UpdateCheck);
+}

--- a/src/Restall.Tests/Application/ModManagementFacadeTests.cs
+++ b/src/Restall.Tests/Application/ModManagementFacadeTests.cs
@@ -11,6 +11,7 @@ namespace Restall.Tests.Application;
 
 public sealed class ModManagementFacadeTests
 {
+    // Verifies that ReShade installation stops before the use case when the game folder is missing.
     [Fact]
     public async Task InstallOrUpdateReShadeAsync_WhenGameFolderIsMissing_ReturnsErrorWithoutCallingUseCase()
     {
@@ -27,6 +28,7 @@ public sealed class ModManagementFacadeTests
             Times.Never);
     }
 
+    // Verifies that a stale ReShade record blocks installation and requests a deep scan.
     [Fact]
     public async Task InstallOrUpdateReShadeAsync_WhenRecordedFileIsMissing_ReturnsStaleRecordError()
     {
@@ -45,6 +47,7 @@ public sealed class ModManagementFacadeTests
             Times.Never);
     }
 
+    // Verifies that successful ReShade installation is enriched with update-check state.
     [Fact]
     public async Task InstallOrUpdateReShadeAsync_WhenInstallSucceeds_AddsUpdateCheckResult()
     {
@@ -70,6 +73,7 @@ public sealed class ModManagementFacadeTests
         context.UpdateCheck.Verify(x => x.CheckReShadeUpdate(installed), Times.Once);
     }
 
+    // Verifies that failed ReShade installation does not run update checking.
     [Fact]
     public async Task InstallOrUpdateReShadeAsync_WhenInstallFails_DoesNotRunUpdateCheck()
     {
@@ -90,6 +94,7 @@ public sealed class ModManagementFacadeTests
         context.UpdateCheck.Verify(x => x.CheckReShadeUpdate(It.IsAny<ReShade>()), Times.Never);
     }
 
+    // Verifies that ReShade uninstall stops before the use case when the game folder is missing.
     [Fact]
     public async Task UninstallReShadeAsync_WhenGameFolderIsMissing_ReturnsErrorWithoutCallingUseCase()
     {
@@ -105,6 +110,7 @@ public sealed class ModManagementFacadeTests
         context.UninstallReShade.Verify(x => x.ExecuteAsync(It.IsAny<Game>()), Times.Never);
     }
 
+    // Verifies that ReShade uninstall fails early when no ReShade record exists.
     [Fact]
     public async Task UninstallReShadeAsync_WhenNoReShadeIsRecorded_ReturnsErrorWithoutCallingUseCase()
     {
@@ -119,6 +125,7 @@ public sealed class ModManagementFacadeTests
         context.UninstallReShade.Verify(x => x.ExecuteAsync(It.IsAny<Game>()), Times.Never);
     }
 
+    // Verifies that ReShade uninstall delegates to the use case when a record exists.
     [Fact]
     public async Task UninstallReShadeAsync_WhenReShadeIsRecorded_CallsUseCase()
     {
@@ -136,6 +143,7 @@ public sealed class ModManagementFacadeTests
         context.UninstallReShade.Verify(x => x.ExecuteAsync(game), Times.Once);
     }
 
+    // Verifies that RenoDX installation stops before the use case when the game folder is missing.
     [Fact]
     public async Task InstallOrUpdateRenoDXAsync_WhenGameFolderIsMissing_ReturnsErrorWithoutCallingUseCase()
     {
@@ -152,6 +160,7 @@ public sealed class ModManagementFacadeTests
             Times.Never);
     }
 
+    // Verifies that a stale RenoDX record blocks installation and requests a deep scan.
     [Fact]
     public async Task InstallOrUpdateRenoDXAsync_WhenRecordedFileIsMissing_ReturnsStaleRecordError()
     {
@@ -170,6 +179,7 @@ public sealed class ModManagementFacadeTests
             Times.Never);
     }
 
+    // Verifies that successful RenoDX installation is enriched with update-check state.
     [Fact]
     public async Task InstallOrUpdateRenoDXAsync_WhenInstallSucceeds_AddsUpdateCheckResult()
     {
@@ -201,6 +211,7 @@ public sealed class ModManagementFacadeTests
         context.UpdateCheck.Verify(x => x.CheckRenoDXUpdate(installed), Times.Once);
     }
 
+    // Verifies that failed RenoDX installation does not run update checking.
     [Fact]
     public async Task InstallOrUpdateRenoDXAsync_WhenInstallFails_DoesNotRunUpdateCheck()
     {
@@ -221,6 +232,7 @@ public sealed class ModManagementFacadeTests
         context.UpdateCheck.Verify(x => x.CheckRenoDXUpdate(It.IsAny<RenoDX>()), Times.Never);
     }
 
+    // Verifies that RenoDX uninstall stops before the use case when the game folder is missing.
     [Fact]
     public async Task UninstallRenoDXAsync_WhenGameFolderIsMissing_ReturnsErrorWithoutCallingUseCase()
     {
@@ -236,6 +248,7 @@ public sealed class ModManagementFacadeTests
         context.UninstallRenoDX.Verify(x => x.ExecuteAsync(It.IsAny<Game>()), Times.Never);
     }
 
+    // Verifies that RenoDX uninstall fails early when no RenoDX record exists.
     [Fact]
     public async Task UninstallRenoDXAsync_WhenNoRenoDXIsRecorded_ReturnsErrorWithoutCallingUseCase()
     {
@@ -250,6 +263,7 @@ public sealed class ModManagementFacadeTests
         context.UninstallRenoDX.Verify(x => x.ExecuteAsync(It.IsAny<Game>()), Times.Never);
     }
 
+    // Verifies that RenoDX uninstall delegates to the use case when a record exists.
     [Fact]
     public async Task UninstallRenoDXAsync_WhenRenoDXIsRecorded_CallsUseCase()
     {

--- a/src/Restall.Tests/Application/RefreshLibraryUseCaseTests.cs
+++ b/src/Restall.Tests/Application/RefreshLibraryUseCaseTests.cs
@@ -1,0 +1,195 @@
+using Moq;
+using Restall.Application.DTOs;
+using Restall.Application.Interfaces.Driven;
+using Restall.Application.UseCases;
+using Restall.Domain.Entities;
+
+namespace Restall.Tests.Application;
+
+public sealed class RefreshLibraryUseCaseTests
+{
+    [Fact]
+    public async Task ExecuteFullRescanAsync_BuildsSortedGameResultsWithDetectedModsCompatibilityAndUpdates()
+    {
+        var context = CreateContext();
+        var alpha = new Game { Name = "Alpha Game", ExecutablePath = "alpha-path" };
+        var dead = new Game { Name = "Dead Game", ExecutablePath = "dead-path" };
+        var zulu = new Game { Name = "Zulu Game", ExecutablePath = "zulu-path" };
+        var games = new[] { zulu, alpha, dead };
+
+        var alphaReShade = new ReShade
+        {
+            BranchName = ReShade.Branch.Stable,
+            SelectedFilename = "dxgi.dll",
+            Version = "6.4.0"
+        };
+        var zuluRenoDX = new RenoDX
+        {
+            BranchName = RenoDX.Branch.Snapshot,
+            OriginalName = "renodx-zulu.addon64",
+            SelectedName = "renodx-zulu.addon64",
+            Version = "20240101"
+        };
+        var alphaUpdate = new UpdateCheckResultDto(true, "6.4.0", "6.5.0");
+        var zuluUpdate = new UpdateCheckResultDto(false, "20240101", "20240101");
+        var zuluSpecificMod = new RenoDXModInfoDto(
+            "Zulu Game",
+            DiscordUrl: null,
+            SnapshotUrl64: "https://example.test/renodx-zulu.addon64",
+            SnapshotUrl32: null,
+            NexusUrl: null,
+            Maintainer: "Maintainer",
+            Notes: null,
+            Status: ":white_check_mark:");
+        var deadSpecificMod = new RenoDXModInfoDto(
+            "Dead Game",
+            DiscordUrl: null,
+            SnapshotUrl64: "https://example.test/renodx-dead.addon64",
+            SnapshotUrl32: null,
+            NexusUrl: null,
+            Maintainer: "Maintainer",
+            Notes: null,
+            Status: "\ud83d\udc80");
+        var alphaGenericMod = new RenoDXGenericModInfoDto(
+            "Alpha Game",
+            ":construction:",
+            SupportedEngine.Unreal,
+            Notes: "generic notes");
+
+        context.GameDetection
+            .Setup(x => x.FindGamesAsync(It.IsAny<IProgress<GameScanProgressReportDto>?>()))
+            .ReturnsAsync(new GameScanResultDto(Game.Platform.Unknown, games, false, "partial scan warning"));
+        context.ModCatalog.Setup(x => x.GetRenoDXWikiMods()).Returns(new[] { zuluSpecificMod, deadSpecificMod });
+        context.ModCatalog.Setup(x => x.GetRenoDXGenericWikiMods()).Returns(new[] { alphaGenericMod });
+        context.ModDetection.Setup(x => x.DetectInstalledReShadeAsync("alpha-path"))
+            .ReturnsAsync(new HashSet<ReShade> { alphaReShade });
+        context.ModDetection.Setup(x => x.DetectInstalledRenoDXAsync("zulu-path"))
+            .ReturnsAsync(new HashSet<RenoDX> { zuluRenoDX });
+        context.UpdateCheck.Setup(x => x.CheckReShadeUpdate(alphaReShade)).Returns(alphaUpdate);
+        context.UpdateCheck.Setup(x => x.CheckRenoDXUpdate(zuluRenoDX)).Returns(zuluUpdate);
+
+        var result = await context.Sut.ExecuteFullRescanAsync();
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("partial scan warning", result.ErrorMessage);
+        Assert.Equal(new[] { "Alpha Game", "Dead Game", "Zulu Game" }, result.Games.Select(g => g.Game.Name));
+
+        var alphaResult = result.Games.Single(g => g.Game.Name == "Alpha Game");
+        Assert.Same(alphaReShade, alphaResult.Game.ReShade);
+        Assert.Null(alphaResult.Game.RenoDX);
+        Assert.Same(alphaGenericMod, alphaResult.CompatibleGenericMod);
+        Assert.Null(alphaResult.CompatibleMod);
+        Assert.Same(alphaUpdate, alphaResult.ReShadeUpdateResult);
+        Assert.Null(alphaResult.RenoDXUpdateResult);
+
+        var deadResult = result.Games.Single(g => g.Game.Name == "Dead Game");
+        Assert.Null(deadResult.CompatibleMod);
+        Assert.Null(deadResult.CompatibleGenericMod);
+
+        var zuluResult = result.Games.Single(g => g.Game.Name == "Zulu Game");
+        Assert.Same(zuluRenoDX, zuluResult.Game.RenoDX);
+        Assert.Same(zuluSpecificMod, zuluResult.CompatibleMod);
+        Assert.Null(zuluResult.CompatibleGenericMod);
+        Assert.Same(zuluUpdate, zuluResult.RenoDXUpdateResult);
+
+        context.GameDetection.Verify(x => x.FindGamesAsync(It.IsAny<IProgress<GameScanProgressReportDto>?>()), Times.Once);
+        context.VersionCatalog.Verify(x => x.FetchVersionsAsync(), Times.Once);
+        context.ModCatalog.Verify(x => x.FetchModsAsync(), Times.Once);
+        context.SteamGridDb.Verify(x => x.EnrichGameArtworkAsync(It.IsAny<Game>()), Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task ExecuteLightRescanAsync_UsesExistingGamesWithoutGameDetectionAndReturnsSuccessfulResult()
+    {
+        var context = CreateContext();
+        var beta = new Game { Name = "Beta Game", ExecutablePath = "beta-path" };
+        var alpha = new Game { Name = "Alpha Game", ExecutablePath = "alpha-path" };
+        var alphaSpecificMod = new RenoDXModInfoDto(
+            "Alpha Game",
+            DiscordUrl: null,
+            SnapshotUrl64: "https://example.test/renodx-alpha.addon64",
+            SnapshotUrl32: null,
+            NexusUrl: null,
+            Maintainer: "Maintainer",
+            Notes: null,
+            Status: ":white_check_mark:");
+        var betaRenoDX = new RenoDX
+        {
+            BranchName = RenoDX.Branch.Snapshot,
+            OriginalName = "renodx-beta.addon64",
+            SelectedName = "renodx-beta.addon64",
+            Version = "20240101"
+        };
+        var betaUpdate = new UpdateCheckResultDto(true, "20240101", "20240202");
+
+        context.ModCatalog.Setup(x => x.GetRenoDXWikiMods()).Returns(new[] { alphaSpecificMod });
+        context.ModCatalog.Setup(x => x.GetRenoDXGenericWikiMods()).Returns(Array.Empty<RenoDXGenericModInfoDto>());
+        context.ModDetection.Setup(x => x.DetectInstalledRenoDXAsync("beta-path"))
+            .ReturnsAsync(new HashSet<RenoDX> { betaRenoDX });
+        context.UpdateCheck.Setup(x => x.CheckRenoDXUpdate(betaRenoDX)).Returns(betaUpdate);
+
+        var result = await context.Sut.ExecuteLightRescanAsync(new[] { beta, alpha });
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.ErrorMessage);
+        Assert.Equal(new[] { "Alpha Game", "Beta Game" }, result.Games.Select(g => g.Game.Name));
+
+        var alphaResult = result.Games.Single(g => g.Game.Name == "Alpha Game");
+        Assert.Same(alphaSpecificMod, alphaResult.CompatibleMod);
+        Assert.Null(alphaResult.CompatibleGenericMod);
+
+        var betaResult = result.Games.Single(g => g.Game.Name == "Beta Game");
+        Assert.Same(betaRenoDX, betaResult.Game.RenoDX);
+        Assert.Same(betaUpdate, betaResult.RenoDXUpdateResult);
+
+        context.GameDetection.Verify(x => x.FindGamesAsync(It.IsAny<IProgress<GameScanProgressReportDto>?>()), Times.Never);
+        context.VersionCatalog.Verify(x => x.FetchVersionsAsync(), Times.Once);
+        context.ModCatalog.Verify(x => x.FetchModsAsync(), Times.Once);
+        context.SteamGridDb.Verify(x => x.EnrichGameArtworkAsync(It.IsAny<Game>()), Times.Exactly(2));
+    }
+
+    private static RefreshContext CreateContext()
+    {
+        var gameDetection = new Mock<IGameDetectionService>(MockBehavior.Strict);
+        var steamGridDb = new Mock<ISteamGridDbService>(MockBehavior.Strict);
+        var modDetection = new Mock<IModDetectionService>(MockBehavior.Strict);
+        var updateCheck = new Mock<IUpdateCheckService>(MockBehavior.Strict);
+        var versionCatalog = new Mock<IVersionCatalog>(MockBehavior.Strict);
+        var modCatalog = new Mock<IModCatalog>(MockBehavior.Strict);
+
+        versionCatalog.Setup(x => x.FetchVersionsAsync()).Returns(Task.CompletedTask);
+        modCatalog.Setup(x => x.FetchModsAsync()).Returns(Task.CompletedTask);
+        steamGridDb.Setup(x => x.EnrichGameArtworkAsync(It.IsAny<Game>())).Returns(Task.CompletedTask);
+        modDetection.Setup(x => x.DetectInstalledReShadeAsync(It.IsAny<string>()))
+            .ReturnsAsync(new HashSet<ReShade>());
+        modDetection.Setup(x => x.DetectInstalledRenoDXAsync(It.IsAny<string>()))
+            .ReturnsAsync(new HashSet<RenoDX>());
+
+        var sut = new RefreshLibraryUseCase(
+            Mock.Of<ILogService>(),
+            gameDetection.Object,
+            steamGridDb.Object,
+            modDetection.Object,
+            updateCheck.Object,
+            versionCatalog.Object,
+            modCatalog.Object);
+
+        return new RefreshContext(
+            sut,
+            gameDetection,
+            steamGridDb,
+            modDetection,
+            updateCheck,
+            versionCatalog,
+            modCatalog);
+    }
+
+    private sealed record RefreshContext(
+        RefreshLibraryUseCase Sut,
+        Mock<IGameDetectionService> GameDetection,
+        Mock<ISteamGridDbService> SteamGridDb,
+        Mock<IModDetectionService> ModDetection,
+        Mock<IUpdateCheckService> UpdateCheck,
+        Mock<IVersionCatalog> VersionCatalog,
+        Mock<IModCatalog> ModCatalog);
+}

--- a/src/Restall.Tests/Application/RefreshLibraryUseCaseTests.cs
+++ b/src/Restall.Tests/Application/RefreshLibraryUseCaseTests.cs
@@ -8,6 +8,7 @@ namespace Restall.Tests.Application;
 
 public sealed class RefreshLibraryUseCaseTests
 {
+    // Verifies that a full rescan combines scanning, detection, compatibility matching, updates, and artwork enrichment.
     [Fact]
     public async Task ExecuteFullRescanAsync_BuildsSortedGameResultsWithDetectedModsCompatibilityAndUpdates()
     {
@@ -98,6 +99,33 @@ public sealed class RefreshLibraryUseCaseTests
         context.SteamGridDb.Verify(x => x.EnrichGameArtworkAsync(It.IsAny<Game>()), Times.Exactly(3));
     }
 
+    // Verifies that a full rescan with no games avoids per-game work while preserving scan status.
+    [Fact]
+    public async Task ExecuteFullRescanAsync_WhenNoGamesAreFound_ReturnsEmptyResultWithoutPerGameWork()
+    {
+        var context = CreateContext();
+
+        context.GameDetection
+            .Setup(x => x.FindGamesAsync(It.IsAny<IProgress<GameScanProgressReportDto>?>()))
+            .ReturnsAsync(new GameScanResultDto(Game.Platform.Unknown, Array.Empty<Game>(), false, "no games found"));
+
+        var result = await context.Sut.ExecuteFullRescanAsync();
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("no games found", result.ErrorMessage);
+        Assert.Empty(result.Games);
+
+        context.GameDetection.Verify(x => x.FindGamesAsync(It.IsAny<IProgress<GameScanProgressReportDto>?>()), Times.Once);
+        context.VersionCatalog.Verify(x => x.FetchVersionsAsync(), Times.Once);
+        context.ModCatalog.Verify(x => x.FetchModsAsync(), Times.Once);
+        context.ModDetection.Verify(x => x.DetectInstalledReShadeAsync(It.IsAny<string>()), Times.Never);
+        context.ModDetection.Verify(x => x.DetectInstalledRenoDXAsync(It.IsAny<string>()), Times.Never);
+        context.ModCatalog.Verify(x => x.GetRenoDXWikiMods(), Times.Never);
+        context.ModCatalog.Verify(x => x.GetRenoDXGenericWikiMods(), Times.Never);
+        context.SteamGridDb.Verify(x => x.EnrichGameArtworkAsync(It.IsAny<Game>()), Times.Never);
+    }
+
+    // Verifies that a light rescan refreshes existing games without invoking platform scanning.
     [Fact]
     public async Task ExecuteLightRescanAsync_UsesExistingGamesWithoutGameDetectionAndReturnsSuccessfulResult()
     {
@@ -146,6 +174,28 @@ public sealed class RefreshLibraryUseCaseTests
         context.VersionCatalog.Verify(x => x.FetchVersionsAsync(), Times.Once);
         context.ModCatalog.Verify(x => x.FetchModsAsync(), Times.Once);
         context.SteamGridDb.Verify(x => x.EnrichGameArtworkAsync(It.IsAny<Game>()), Times.Exactly(2));
+    }
+
+    // Verifies that a light rescan with no existing games refreshes catalogs but skips per-game work.
+    [Fact]
+    public async Task ExecuteLightRescanAsync_WhenNoExistingGamesAreProvided_ReturnsEmptySuccessfulResult()
+    {
+        var context = CreateContext();
+
+        var result = await context.Sut.ExecuteLightRescanAsync(Array.Empty<Game>());
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.ErrorMessage);
+        Assert.Empty(result.Games);
+
+        context.GameDetection.Verify(x => x.FindGamesAsync(It.IsAny<IProgress<GameScanProgressReportDto>?>()), Times.Never);
+        context.VersionCatalog.Verify(x => x.FetchVersionsAsync(), Times.Once);
+        context.ModCatalog.Verify(x => x.FetchModsAsync(), Times.Once);
+        context.ModDetection.Verify(x => x.DetectInstalledReShadeAsync(It.IsAny<string>()), Times.Never);
+        context.ModDetection.Verify(x => x.DetectInstalledRenoDXAsync(It.IsAny<string>()), Times.Never);
+        context.ModCatalog.Verify(x => x.GetRenoDXWikiMods(), Times.Never);
+        context.ModCatalog.Verify(x => x.GetRenoDXGenericWikiMods(), Times.Never);
+        context.SteamGridDb.Verify(x => x.EnrichGameArtworkAsync(It.IsAny<Game>()), Times.Never);
     }
 
     private static RefreshContext CreateContext()

--- a/src/Restall.Tests/Application/RenoDXDtoTests.cs
+++ b/src/Restall.Tests/Application/RenoDXDtoTests.cs
@@ -1,0 +1,141 @@
+using Restall.Application.DTOs;
+using Restall.Domain.Entities;
+
+namespace Restall.Tests.Application;
+
+public sealed class RenoDXDtoTests
+{
+    // Verifies that RenoDX wiki addon filenames are extracted from x64 and x32 snapshot URLs.
+    [Fact]
+    public void RenoDXModInfoDto_WhenSnapshotUrlsAreValid_ExtractsAddonFilenames()
+    {
+        var dto = CreateModInfo(
+            snapshot64: "https://example.test/downloads/renodx-game.addon64",
+            snapshot32: "https://example.test/downloads/renodx-game.addon32");
+
+        Assert.Equal("renodx-game.addon64", dto.AddonFilename64);
+        Assert.Equal("renodx-game.addon32", dto.AddonFilename32);
+    }
+
+    // Verifies that invalid or missing snapshot URLs do not produce addon filenames.
+    [Fact]
+    public void RenoDXModInfoDto_WhenSnapshotUrlsAreInvalid_ReturnsNullAddonFilenames()
+    {
+        var dto = CreateModInfo(snapshot64: "not a url", snapshot32: null);
+
+        Assert.Null(dto.AddonFilename64);
+        Assert.Null(dto.AddonFilename32);
+        Assert.False(dto.HasWikiFilename);
+    }
+
+    // Verifies that x64-only RenoDX metadata reports x64-only support flags.
+    [Fact]
+    public void RenoDXModInfoDto_WhenOnlyX64UrlExists_ReportsX64OnlySupport()
+    {
+        var dto = CreateModInfo(snapshot64: "https://example.test/renodx-game.addon64");
+
+        Assert.True(dto.SupportsX64);
+        Assert.False(dto.SupportsX32);
+        Assert.False(dto.IsDualArch);
+        Assert.True(dto.HasWikiFilename);
+    }
+
+    // Verifies that x32-only RenoDX metadata reports x32-only support flags.
+    [Fact]
+    public void RenoDXModInfoDto_WhenOnlyX32UrlExists_ReportsX32OnlySupport()
+    {
+        var dto = CreateModInfo(snapshot32: "https://example.test/renodx-game.addon32");
+
+        Assert.False(dto.SupportsX64);
+        Assert.True(dto.SupportsX32);
+        Assert.False(dto.IsDualArch);
+        Assert.True(dto.HasWikiFilename);
+    }
+
+    // Verifies that dual-architecture RenoDX metadata reports dual support flags.
+    [Fact]
+    public void RenoDXModInfoDto_WhenBothSnapshotUrlsExist_ReportsDualArchSupport()
+    {
+        var dto = CreateModInfo(
+            snapshot64: "https://example.test/renodx-game.addon64",
+            snapshot32: "https://example.test/renodx-game.addon32");
+
+        Assert.True(dto.SupportsX64);
+        Assert.True(dto.SupportsX32);
+        Assert.True(dto.IsDualArch);
+        Assert.True(dto.HasWikiFilename);
+    }
+
+    // Verifies that manual source preference prioritizes Nexus before Discord.
+    [Fact]
+    public void PreferredManualSource_WhenNexusAndDiscordExist_ReturnsNexus()
+    {
+        var dto = CreateModInfo(
+            discordUrl: "https://discord.test/mod",
+            nexusUrl: "https://nexusmods.com/game/mod");
+
+        Assert.Equal(RenoDXModSource.Nexus, dto.PreferredManualSource);
+    }
+
+    // Verifies that manual source preference falls back to Discord when Nexus is absent.
+    [Fact]
+    public void PreferredManualSource_WhenOnlyDiscordExists_ReturnsDiscord()
+    {
+        var dto = CreateModInfo(discordUrl: "https://discord.test/mod");
+
+        Assert.Equal(RenoDXModSource.Discord, dto.PreferredManualSource);
+    }
+
+    // Verifies that manual source preference returns Unknown when no manual source exists.
+    [Fact]
+    public void PreferredManualSource_WhenNoManualSourceExists_ReturnsUnknown()
+    {
+        var dto = CreateModInfo();
+
+        Assert.Equal(RenoDXModSource.Unknown, dto.PreferredManualSource);
+    }
+
+    // Verifies that generic RenoDX metadata builds Unreal addon names.
+    [Fact]
+    public void RenoDXGenericModInfoDto_WhenEngineIsUnreal_ReturnsUnrealAddonNames()
+    {
+        var dto = new RenoDXGenericModInfoDto("Unreal", ":white_check_mark:", SupportedEngine.Unreal);
+
+        Assert.Equal("renodx-unrealengine.addon64", dto.AddonFilename64);
+        Assert.Equal("renodx-unrealengine.addon32", dto.AddonFilename32);
+    }
+
+    // Verifies that generic RenoDX metadata builds Unity addon names.
+    [Fact]
+    public void RenoDXGenericModInfoDto_WhenEngineIsUnity_ReturnsUnityAddonNames()
+    {
+        var dto = new RenoDXGenericModInfoDto("Unity", ":white_check_mark:", SupportedEngine.Unity);
+
+        Assert.Equal("renodx-unityengine.addon64", dto.AddonFilename64);
+        Assert.Equal("renodx-unityengine.addon32", dto.AddonFilename32);
+    }
+
+    // Verifies that RenoDX tag versions are formatted as yyyyMMdd.
+    [Fact]
+    public void RenoDXTagInfoDto_Version_FormatsDateAsCompactYearMonthDay()
+    {
+        var dto = new RenoDXTagInfoDto(new DateOnly(2024, 2, 3), RenoDX.Branch.Snapshot);
+
+        Assert.Equal("20240203", dto.Version);
+    }
+
+    private static RenoDXModInfoDto CreateModInfo(
+        string? snapshot64 = null,
+        string? snapshot32 = null,
+        string? discordUrl = null,
+        string? nexusUrl = null) =>
+        new(
+            "Test Game",
+            discordUrl,
+            snapshot64,
+            snapshot32,
+            nexusUrl,
+            "Maintainer",
+            null,
+            ":white_check_mark:");
+}

--- a/src/Restall.Tests/Application/UninstallUseCaseTests.cs
+++ b/src/Restall.Tests/Application/UninstallUseCaseTests.cs
@@ -1,0 +1,76 @@
+using Moq;
+using Restall.Application.DTOs;
+using Restall.Application.Interfaces.Driven;
+using Restall.Application.UseCases;
+using Restall.Domain.Entities;
+
+namespace Restall.Tests.Application;
+
+public sealed class UninstallUseCaseTests
+{
+    // Verifies that ReShade uninstall delegates to the mod install service with the same game instance.
+    [Fact]
+    public async Task UninstallReShadeUseCase_ExecuteAsync_CallsModInstallServiceWithSameGame()
+    {
+        var game = new Game { Name = "Game" };
+        var expected = new ModOperationResultDto(true, game);
+        var modInstall = new Mock<IModInstallService>(MockBehavior.Strict);
+        modInstall.Setup(x => x.UninstallReShadeAsync(game)).ReturnsAsync(expected);
+        var sut = new UninstallReShadeUseCase(modInstall.Object);
+
+        var result = await sut.ExecuteAsync(game);
+
+        Assert.Same(expected, result);
+        modInstall.Verify(x => x.UninstallReShadeAsync(game), Times.Once);
+    }
+
+    // Verifies that ReShade uninstall failures are returned unchanged.
+    [Fact]
+    public async Task UninstallReShadeUseCase_ExecuteAsync_WhenServiceFails_ReturnsFailureResult()
+    {
+        var game = new Game { Name = "Game" };
+        var expected = new ModOperationResultDto(false, game, "Failed", ShouldPromptForDeepScan: true);
+        var modInstall = new Mock<IModInstallService>(MockBehavior.Strict);
+        modInstall.Setup(x => x.UninstallReShadeAsync(game)).ReturnsAsync(expected);
+        var sut = new UninstallReShadeUseCase(modInstall.Object);
+
+        var result = await sut.ExecuteAsync(game);
+
+        Assert.Same(expected, result);
+        Assert.False(result.IsSuccess);
+        Assert.True(result.ShouldPromptForDeepScan);
+    }
+
+    // Verifies that RenoDX uninstall delegates to the mod install service with the same game instance.
+    [Fact]
+    public async Task UninstallRenoDXUseCase_ExecuteAsync_CallsModInstallServiceWithSameGame()
+    {
+        var game = new Game { Name = "Game" };
+        var expected = new ModOperationResultDto(true, game);
+        var modInstall = new Mock<IModInstallService>(MockBehavior.Strict);
+        modInstall.Setup(x => x.UninstallRenoDXAsync(game)).ReturnsAsync(expected);
+        var sut = new UninstallRenoDXUseCase(modInstall.Object);
+
+        var result = await sut.ExecuteAsync(game);
+
+        Assert.Same(expected, result);
+        modInstall.Verify(x => x.UninstallRenoDXAsync(game), Times.Once);
+    }
+
+    // Verifies that RenoDX uninstall failures are returned unchanged.
+    [Fact]
+    public async Task UninstallRenoDXUseCase_ExecuteAsync_WhenServiceFails_ReturnsFailureResult()
+    {
+        var game = new Game { Name = "Game" };
+        var expected = new ModOperationResultDto(false, game, "Failed", ShouldPromptForDeepScan: true);
+        var modInstall = new Mock<IModInstallService>(MockBehavior.Strict);
+        modInstall.Setup(x => x.UninstallRenoDXAsync(game)).ReturnsAsync(expected);
+        var sut = new UninstallRenoDXUseCase(modInstall.Object);
+
+        var result = await sut.ExecuteAsync(game);
+
+        Assert.Same(expected, result);
+        Assert.False(result.IsSuccess);
+        Assert.True(result.ShouldPromptForDeepScan);
+    }
+}

--- a/src/Restall.Tests/Application/UpdateCheckServiceTests.cs
+++ b/src/Restall.Tests/Application/UpdateCheckServiceTests.cs
@@ -1,0 +1,316 @@
+using Moq;
+using Restall.Application.DTOs;
+using Restall.Application.Interfaces.Driven;
+using Restall.Application.Services;
+using Restall.Domain.Entities;
+
+namespace Restall.Tests.Application;
+
+public sealed class UpdateCheckServiceTests
+{
+    [Fact]
+    public void CheckReShadeUpdate_WhenLatestVersionIsNewer_ReturnsUpdateAvailable()
+    {
+        var catalog = CreateVersionCatalog();
+        catalog.Setup(c => c.GetLatestReShadeVersion(ReShade.Branch.Stable)).Returns("6.5.0");
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckReShadeUpdate(new ReShade
+        {
+            BranchName = ReShade.Branch.Stable,
+            Version = "6.4.0"
+        });
+
+        Assert.True(result.UpdateAvailable);
+        Assert.Equal("6.4.0", result.InstalledVersion);
+        Assert.Equal("6.5.0", result.LatestVersion);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("6.5.0", "6.5.0")]
+    [InlineData("6.6.0", "6.5.0")]
+    public void CheckReShadeUpdate_WhenLatestVersionIsNotNewer_ReturnsNoUpdate(
+        string installedVersion,
+        string latestVersion)
+    {
+        var catalog = CreateVersionCatalog();
+        catalog.Setup(c => c.GetLatestReShadeVersion(ReShade.Branch.Stable)).Returns(latestVersion);
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckReShadeUpdate(new ReShade
+        {
+            BranchName = ReShade.Branch.Stable,
+            Version = installedVersion
+        });
+
+        Assert.False(result.UpdateAvailable);
+        Assert.Equal(installedVersion, result.InstalledVersion);
+        Assert.Equal(latestVersion, result.LatestVersion);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void CheckReShadeUpdate_WhenBranchIsUnknown_UsesStableBranch()
+    {
+        var catalog = CreateVersionCatalog();
+        catalog.Setup(c => c.GetLatestReShadeVersion(ReShade.Branch.Stable)).Returns("6.5.0");
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckReShadeUpdate(new ReShade
+        {
+            BranchName = ReShade.Branch.Unknown,
+            Version = "6.4.0"
+        });
+
+        Assert.True(result.UpdateAvailable);
+        catalog.Verify(c => c.GetLatestReShadeVersion(ReShade.Branch.Stable), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(null, "6.5.0")]
+    [InlineData("", "6.5.0")]
+    [InlineData(" ", "6.5.0")]
+    [InlineData("6.4.0", null)]
+    [InlineData("6.4.0", "")]
+    [InlineData("6.4.0", " ")]
+    public void CheckReShadeUpdate_WhenInstalledOrLatestVersionIsMissing_ReturnsNoUpdate(
+        string? installedVersion,
+        string? latestVersion)
+    {
+        var catalog = CreateVersionCatalog();
+        catalog.Setup(c => c.GetLatestReShadeVersion(ReShade.Branch.Stable)).Returns(latestVersion);
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckReShadeUpdate(new ReShade
+        {
+            BranchName = ReShade.Branch.Stable,
+            Version = installedVersion
+        });
+
+        Assert.False(result.UpdateAvailable);
+        Assert.Equal(installedVersion, result.InstalledVersion);
+        Assert.Equal(latestVersion, result.LatestVersion);
+        Assert.Null(result.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("not-a-version", "6.5.0")]
+    [InlineData("6.4.0", "latest")]
+    public void CheckReShadeUpdate_WhenVersionCannotBeParsed_ReturnsErrorMessage(
+        string installedVersion,
+        string latestVersion)
+    {
+        var catalog = CreateVersionCatalog();
+        catalog.Setup(c => c.GetLatestReShadeVersion(ReShade.Branch.Stable)).Returns(latestVersion);
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckReShadeUpdate(new ReShade
+        {
+            BranchName = ReShade.Branch.Stable,
+            Version = installedVersion
+        });
+
+        Assert.False(result.UpdateAvailable);
+        Assert.Equal(installedVersion, result.InstalledVersion);
+        Assert.Equal(latestVersion, result.LatestVersion);
+        Assert.Contains("Could not get ReShade versions", result.ErrorMessage);
+    }
+
+    [Fact]
+    public void CheckRenoDXUpdate_WhenLatestSnapshotIsNewer_ReturnsUpdateAvailable()
+    {
+        var catalog = CreateVersionCatalog();
+        catalog.Setup(c => c.GetLatestRenoDXVersionByTag(RenoDX.Branch.Snapshot))
+            .Returns(Tag(2024, 2, 2, RenoDX.Branch.Snapshot));
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckRenoDXUpdate(new RenoDX
+        {
+            BranchName = RenoDX.Branch.Snapshot,
+            Version = "20240101"
+        });
+
+        Assert.True(result.UpdateAvailable);
+        Assert.Equal("20240101", result.InstalledVersion);
+        Assert.Equal("20240202", result.LatestVersion);
+    }
+
+    [Fact]
+    public void CheckRenoDXUpdate_WhenLatestSnapshotIsSameDate_ReturnsNoUpdate()
+    {
+        var catalog = CreateVersionCatalog();
+        catalog.Setup(c => c.GetLatestRenoDXVersionByTag(RenoDX.Branch.Snapshot))
+            .Returns(Tag(2024, 1, 1, RenoDX.Branch.Snapshot));
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckRenoDXUpdate(new RenoDX
+        {
+            BranchName = RenoDX.Branch.Snapshot,
+            Version = "20240101"
+        });
+
+        Assert.False(result.UpdateAvailable);
+        Assert.Equal("20240101", result.InstalledVersion);
+        Assert.Equal("20240101", result.LatestVersion);
+    }
+
+    [Fact]
+    public void CheckRenoDXUpdate_WhenBranchIsUnknown_UsesSnapshotBranch()
+    {
+        var catalog = CreateVersionCatalog();
+        catalog.Setup(c => c.GetLatestRenoDXVersionByTag(RenoDX.Branch.Snapshot))
+            .Returns(Tag(2024, 2, 2, RenoDX.Branch.Snapshot));
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckRenoDXUpdate(new RenoDX
+        {
+            BranchName = RenoDX.Branch.Unknown,
+            Version = "20240101"
+        });
+
+        Assert.True(result.UpdateAvailable);
+        catalog.Verify(c => c.GetLatestRenoDXVersionByTag(RenoDX.Branch.Snapshot), Times.Once);
+    }
+
+    [Fact]
+    public void CheckRenoDXUpdate_WhenBranchIsWiki_UsesSnapshotBranch()
+    {
+        var catalog = CreateVersionCatalog();
+        catalog.Setup(c => c.GetLatestRenoDXVersionByTag(RenoDX.Branch.Snapshot))
+            .Returns(Tag(2024, 2, 2, RenoDX.Branch.Snapshot));
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckRenoDXUpdate(new RenoDX
+        {
+            BranchName = RenoDX.Branch.Wiki,
+            Version = "20240101"
+        });
+
+        Assert.True(result.UpdateAvailable);
+        catalog.Verify(c => c.GetLatestRenoDXVersionByTag(RenoDX.Branch.Snapshot), Times.Once);
+        catalog.Verify(c => c.GetLatestRenoDXVersionByTag(RenoDX.Branch.Wiki), Times.Never);
+    }
+
+    [Fact]
+    public void CheckRenoDXUpdate_WhenBranchIsNightly_UsesNightlyBranch()
+    {
+        var catalog = CreateVersionCatalog();
+        catalog.Setup(c => c.GetLatestRenoDXVersionByTag(RenoDX.Branch.Nightly))
+            .Returns(Tag(2024, 2, 2, RenoDX.Branch.Nightly));
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckRenoDXUpdate(new RenoDX
+        {
+            BranchName = RenoDX.Branch.Nightly,
+            Version = "20240101"
+        });
+
+        Assert.True(result.UpdateAvailable);
+        catalog.Verify(c => c.GetLatestRenoDXVersionByTag(RenoDX.Branch.Nightly), Times.Once);
+    }
+
+    [Fact]
+    public void CheckRenoDXUpdate_WhenModIsExternalUnitySource_ReturnsNoUpdateWithoutCatalogLookup()
+    {
+        var catalog = CreateVersionCatalog();
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckRenoDXUpdate(new RenoDX
+        {
+            OriginalName = "renodx-unityengine.addon64",
+            BranchName = RenoDX.Branch.Snapshot,
+            Version = "20240101"
+        });
+
+        Assert.False(result.UpdateAvailable);
+        Assert.Equal("20240101", result.InstalledVersion);
+        Assert.Null(result.LatestVersion);
+        catalog.Verify(c => c.GetLatestRenoDXVersionByTag(It.IsAny<RenoDX.Branch>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void CheckRenoDXUpdate_WhenInstalledVersionIsMissing_ReturnsNoUpdate(string? installedVersion)
+    {
+        var catalog = CreateVersionCatalog();
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckRenoDXUpdate(new RenoDX
+        {
+            BranchName = RenoDX.Branch.Snapshot,
+            Version = installedVersion
+        });
+
+        Assert.False(result.UpdateAvailable);
+        Assert.Null(result.InstalledVersion);
+        Assert.Null(result.LatestVersion);
+        catalog.Verify(c => c.GetLatestRenoDXVersionByTag(It.IsAny<RenoDX.Branch>()), Times.Never);
+    }
+
+    [Fact]
+    public void CheckRenoDXUpdate_WhenLatestTagIsMissing_ReturnsNoUpdate()
+    {
+        var catalog = CreateVersionCatalog();
+        catalog.Setup(c => c.GetLatestRenoDXVersionByTag(RenoDX.Branch.Snapshot)).Returns((RenoDXTagInfoDto?)null);
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckRenoDXUpdate(new RenoDX
+        {
+            BranchName = RenoDX.Branch.Snapshot,
+            Version = "20240101"
+        });
+
+        Assert.False(result.UpdateAvailable);
+        Assert.Equal("20240101", result.InstalledVersion);
+        Assert.Null(result.LatestVersion);
+    }
+
+    [Fact]
+    public void CheckRenoDXUpdate_WhenInstalledVersionCannotBeParsed_ReturnsErrorMessage()
+    {
+        var catalog = CreateVersionCatalog();
+        catalog.Setup(c => c.GetLatestRenoDXVersionByTag(RenoDX.Branch.Snapshot))
+            .Returns(Tag(2024, 2, 2, RenoDX.Branch.Snapshot));
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckRenoDXUpdate(new RenoDX
+        {
+            BranchName = RenoDX.Branch.Snapshot,
+            Version = "not-a-date"
+        });
+
+        Assert.False(result.UpdateAvailable);
+        Assert.Equal("not-a-date", result.InstalledVersion);
+        Assert.Equal("20240202", result.LatestVersion);
+        Assert.Contains("Could not get date from installed RenoDX version", result.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData(RenoDX.Branch.Discord)]
+    [InlineData(RenoDX.Branch.Nexus)]
+    public void CheckRenoDXUpdate_WhenBranchDoesNotSupportAutomatedUpdates_ReturnsNoUpdate(
+        RenoDX.Branch branch)
+    {
+        var catalog = CreateVersionCatalog();
+        var service = new UpdateCheckService(catalog.Object);
+
+        var result = service.CheckRenoDXUpdate(new RenoDX
+        {
+            BranchName = branch,
+            Version = "20240101"
+        });
+
+        Assert.False(result.UpdateAvailable);
+        Assert.Equal("20240101", result.InstalledVersion);
+        Assert.Null(result.LatestVersion);
+        catalog.Verify(c => c.GetLatestRenoDXVersionByTag(It.IsAny<RenoDX.Branch>()), Times.Never);
+    }
+
+    private static Mock<IVersionCatalog> CreateVersionCatalog() => new(MockBehavior.Strict);
+
+    private static RenoDXTagInfoDto Tag(int year, int month, int day, RenoDX.Branch branch) =>
+        new(new DateOnly(year, month, day), branch);
+}

--- a/src/Restall.Tests/Application/UpdateCheckServiceTests.cs
+++ b/src/Restall.Tests/Application/UpdateCheckServiceTests.cs
@@ -8,6 +8,7 @@ namespace Restall.Tests.Application;
 
 public sealed class UpdateCheckServiceTests
 {
+    // Verifies that ReShade reports an update when the catalog version is newer.
     [Fact]
     public void CheckReShadeUpdate_WhenLatestVersionIsNewer_ReturnsUpdateAvailable()
     {
@@ -27,6 +28,7 @@ public sealed class UpdateCheckServiceTests
         Assert.Null(result.ErrorMessage);
     }
 
+    // Verifies that ReShade does not report an update for same or newer installed versions.
     [Theory]
     [InlineData("6.5.0", "6.5.0")]
     [InlineData("6.6.0", "6.5.0")]
@@ -50,6 +52,7 @@ public sealed class UpdateCheckServiceTests
         Assert.Null(result.ErrorMessage);
     }
 
+    // Verifies that unknown ReShade branch records fall back to the Stable catalog branch.
     [Fact]
     public void CheckReShadeUpdate_WhenBranchIsUnknown_UsesStableBranch()
     {
@@ -67,6 +70,7 @@ public sealed class UpdateCheckServiceTests
         catalog.Verify(c => c.GetLatestReShadeVersion(ReShade.Branch.Stable), Times.Once);
     }
 
+    // Verifies that missing ReShade version data returns a safe no-update result.
     [Theory]
     [InlineData(null, "6.5.0")]
     [InlineData("", "6.5.0")]
@@ -94,6 +98,7 @@ public sealed class UpdateCheckServiceTests
         Assert.Null(result.ErrorMessage);
     }
 
+    // Verifies that malformed ReShade versions return a parse error instead of an update.
     [Theory]
     [InlineData("not-a-version", "6.5.0")]
     [InlineData("6.4.0", "latest")]
@@ -117,6 +122,7 @@ public sealed class UpdateCheckServiceTests
         Assert.Contains("Could not get ReShade versions", result.ErrorMessage);
     }
 
+    // Verifies that RenoDX snapshot reports an update when the catalog date is newer.
     [Fact]
     public void CheckRenoDXUpdate_WhenLatestSnapshotIsNewer_ReturnsUpdateAvailable()
     {
@@ -136,6 +142,7 @@ public sealed class UpdateCheckServiceTests
         Assert.Equal("20240202", result.LatestVersion);
     }
 
+    // Verifies that RenoDX snapshot does not report an update when dates match.
     [Fact]
     public void CheckRenoDXUpdate_WhenLatestSnapshotIsSameDate_ReturnsNoUpdate()
     {
@@ -155,6 +162,7 @@ public sealed class UpdateCheckServiceTests
         Assert.Equal("20240101", result.LatestVersion);
     }
 
+    // Verifies that unknown RenoDX branch records fall back to Snapshot.
     [Fact]
     public void CheckRenoDXUpdate_WhenBranchIsUnknown_UsesSnapshotBranch()
     {
@@ -173,6 +181,7 @@ public sealed class UpdateCheckServiceTests
         catalog.Verify(c => c.GetLatestRenoDXVersionByTag(RenoDX.Branch.Snapshot), Times.Once);
     }
 
+    // Verifies that Wiki-sourced RenoDX records compare against Snapshot releases.
     [Fact]
     public void CheckRenoDXUpdate_WhenBranchIsWiki_UsesSnapshotBranch()
     {
@@ -192,6 +201,7 @@ public sealed class UpdateCheckServiceTests
         catalog.Verify(c => c.GetLatestRenoDXVersionByTag(RenoDX.Branch.Wiki), Times.Never);
     }
 
+    // Verifies that Nightly RenoDX records use the Nightly catalog branch.
     [Fact]
     public void CheckRenoDXUpdate_WhenBranchIsNightly_UsesNightlyBranch()
     {
@@ -210,6 +220,7 @@ public sealed class UpdateCheckServiceTests
         catalog.Verify(c => c.GetLatestRenoDXVersionByTag(RenoDX.Branch.Nightly), Times.Once);
     }
 
+    // Verifies that external Unity RenoDX mods skip automated update checks.
     [Fact]
     public void CheckRenoDXUpdate_WhenModIsExternalUnitySource_ReturnsNoUpdateWithoutCatalogLookup()
     {
@@ -229,6 +240,7 @@ public sealed class UpdateCheckServiceTests
         catalog.Verify(c => c.GetLatestRenoDXVersionByTag(It.IsAny<RenoDX.Branch>()), Times.Never);
     }
 
+    // Verifies that missing RenoDX installed versions return a safe no-update result.
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -250,6 +262,7 @@ public sealed class UpdateCheckServiceTests
         catalog.Verify(c => c.GetLatestRenoDXVersionByTag(It.IsAny<RenoDX.Branch>()), Times.Never);
     }
 
+    // Verifies that absent RenoDX catalog data returns no update instead of failing.
     [Fact]
     public void CheckRenoDXUpdate_WhenLatestTagIsMissing_ReturnsNoUpdate()
     {
@@ -268,6 +281,7 @@ public sealed class UpdateCheckServiceTests
         Assert.Null(result.LatestVersion);
     }
 
+    // Verifies that malformed RenoDX date versions return a parse error.
     [Fact]
     public void CheckRenoDXUpdate_WhenInstalledVersionCannotBeParsed_ReturnsErrorMessage()
     {
@@ -288,6 +302,7 @@ public sealed class UpdateCheckServiceTests
         Assert.Contains("Could not get date from installed RenoDX version", result.ErrorMessage);
     }
 
+    // Verifies that manual RenoDX source branches do not perform catalog lookups.
     [Theory]
     [InlineData(RenoDX.Branch.Discord)]
     [InlineData(RenoDX.Branch.Nexus)]

--- a/src/Restall.Tests/Domain/GameTests.cs
+++ b/src/Restall.Tests/Domain/GameTests.cs
@@ -1,0 +1,38 @@
+using Restall.Domain.Entities;
+
+namespace Restall.Tests.Domain;
+
+public sealed class GameTests
+{
+    [Fact]
+    public void HasReShade_WhenReShadeIsNull_ReturnsFalse()
+    {
+        var game = new Game();
+
+        Assert.False(game.HasReShade);
+    }
+
+    [Fact]
+    public void HasReShade_WhenReShadeIsSet_ReturnsTrue()
+    {
+        var game = new Game { ReShade = new ReShade() };
+
+        Assert.True(game.HasReShade);
+    }
+
+    [Fact]
+    public void HasRenoDX_WhenRenoDXIsNull_ReturnsFalse()
+    {
+        var game = new Game();
+
+        Assert.False(game.HasRenoDX);
+    }
+
+    [Fact]
+    public void HasRenoDX_WhenRenoDXIsSet_ReturnsTrue()
+    {
+        var game = new Game { RenoDX = new RenoDX() };
+
+        Assert.True(game.HasRenoDX);
+    }
+}

--- a/src/Restall.Tests/Domain/GameTests.cs
+++ b/src/Restall.Tests/Domain/GameTests.cs
@@ -4,6 +4,7 @@ namespace Restall.Tests.Domain;
 
 public sealed class GameTests
 {
+    // Verifies that a game without ReShade is reported as not having ReShade.
     [Fact]
     public void HasReShade_WhenReShadeIsNull_ReturnsFalse()
     {
@@ -12,6 +13,7 @@ public sealed class GameTests
         Assert.False(game.HasReShade);
     }
 
+    // Verifies that a game with a ReShade record is reported as having ReShade.
     [Fact]
     public void HasReShade_WhenReShadeIsSet_ReturnsTrue()
     {
@@ -20,6 +22,7 @@ public sealed class GameTests
         Assert.True(game.HasReShade);
     }
 
+    // Verifies that a game without RenoDX is reported as not having RenoDX.
     [Fact]
     public void HasRenoDX_WhenRenoDXIsNull_ReturnsFalse()
     {
@@ -28,6 +31,7 @@ public sealed class GameTests
         Assert.False(game.HasRenoDX);
     }
 
+    // Verifies that a game with a RenoDX record is reported as having RenoDX.
     [Fact]
     public void HasRenoDX_WhenRenoDXIsSet_ReturnsTrue()
     {

--- a/src/Restall.Tests/Domain/ReShadeTests.cs
+++ b/src/Restall.Tests/Domain/ReShadeTests.cs
@@ -1,0 +1,37 @@
+using Restall.Domain.Entities;
+
+namespace Restall.Tests.Domain;
+
+public sealed class ReShadeTests
+{
+    [Theory]
+    [InlineData(ReShade.Filename.Dxgi, ReShade.FileExtension.Dll, "dxgi.dll")]
+    [InlineData(ReShade.Filename.D3d12, ReShade.FileExtension.Dll, "d3d12.dll")]
+    [InlineData(ReShade.Filename.Version, ReShade.FileExtension.Asi, "version.asi")]
+    [InlineData(ReShade.Filename.ReShade64, ReShade.FileExtension.Asi, "ReShade64.asi")]
+    public void GetFileName_CombinesFilenameAndExtension(
+        ReShade.Filename filename,
+        ReShade.FileExtension extension,
+        string expected)
+    {
+        var result = ReShade.GetFileName(filename, extension);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void OriginalFileName_WhenArchitectureIsX64_ReturnsReShade64Dll()
+    {
+        var reShade = new ReShade { Arch = ReShade.Architecture.x64 };
+
+        Assert.Equal("ReShade64.dll", reShade.OriginalFileName);
+    }
+
+    [Fact]
+    public void OriginalFileName_WhenArchitectureIsX32_ReturnsReShade32Dll()
+    {
+        var reShade = new ReShade { Arch = ReShade.Architecture.x32 };
+
+        Assert.Equal("ReShade32.dll", reShade.OriginalFileName);
+    }
+}

--- a/src/Restall.Tests/Domain/ReShadeTests.cs
+++ b/src/Restall.Tests/Domain/ReShadeTests.cs
@@ -4,6 +4,7 @@ namespace Restall.Tests.Domain;
 
 public sealed class ReShadeTests
 {
+    // Verifies that ReShade filename options combine with dll and asi extensions correctly.
     [Theory]
     [InlineData(ReShade.Filename.Dxgi, ReShade.FileExtension.Dll, "dxgi.dll")]
     [InlineData(ReShade.Filename.D3d12, ReShade.FileExtension.Dll, "d3d12.dll")]
@@ -19,6 +20,7 @@ public sealed class ReShadeTests
         Assert.Equal(expected, result);
     }
 
+    // Verifies that x64 ReShade installers expose the expected original DLL name.
     [Fact]
     public void OriginalFileName_WhenArchitectureIsX64_ReturnsReShade64Dll()
     {
@@ -27,6 +29,7 @@ public sealed class ReShadeTests
         Assert.Equal("ReShade64.dll", reShade.OriginalFileName);
     }
 
+    // Verifies that x32 ReShade installers expose the expected original DLL name.
     [Fact]
     public void OriginalFileName_WhenArchitectureIsX32_ReturnsReShade32Dll()
     {

--- a/src/Restall.Tests/Domain/RenoDXTests.cs
+++ b/src/Restall.Tests/Domain/RenoDXTests.cs
@@ -4,6 +4,7 @@ namespace Restall.Tests.Domain;
 
 public sealed class RenoDXTests
 {
+    // Verifies that Unity engine RenoDX addon names are treated as external-source mods.
     [Theory]
     [InlineData("renodx-unityengine.addon64")]
     [InlineData("ReNoDX-UnityEngine.addon32")]
@@ -14,6 +15,7 @@ public sealed class RenoDXTests
         Assert.True(renoDX.IsExternalSourceMod);
     }
 
+    // Verifies that non-Unity RenoDX addon names are not treated as external-source mods.
     [Theory]
     [InlineData("renodx-unrealengine.addon64")]
     [InlineData("renodx-game.addon64")]
@@ -25,6 +27,7 @@ public sealed class RenoDXTests
         Assert.False(renoDX.IsExternalSourceMod);
     }
 
+    // Verifies that missing RenoDX original names are not treated as external-source mods.
     [Fact]
     public void IsExternalSourceMod_WhenOriginalNameIsNull_ReturnsFalse()
     {

--- a/src/Restall.Tests/Domain/RenoDXTests.cs
+++ b/src/Restall.Tests/Domain/RenoDXTests.cs
@@ -1,0 +1,35 @@
+using Restall.Domain.Entities;
+
+namespace Restall.Tests.Domain;
+
+public sealed class RenoDXTests
+{
+    [Theory]
+    [InlineData("renodx-unityengine.addon64")]
+    [InlineData("ReNoDX-UnityEngine.addon32")]
+    public void IsExternalSourceMod_WhenOriginalNameIsUnityEngineMod_ReturnsTrue(string originalName)
+    {
+        var renoDX = new RenoDX { OriginalName = originalName };
+
+        Assert.True(renoDX.IsExternalSourceMod);
+    }
+
+    [Theory]
+    [InlineData("renodx-unrealengine.addon64")]
+    [InlineData("renodx-game.addon64")]
+    [InlineData("unityengine-renodx.addon64")]
+    public void IsExternalSourceMod_WhenOriginalNameIsNotUnityEngineMod_ReturnsFalse(string originalName)
+    {
+        var renoDX = new RenoDX { OriginalName = originalName };
+
+        Assert.False(renoDX.IsExternalSourceMod);
+    }
+
+    [Fact]
+    public void IsExternalSourceMod_WhenOriginalNameIsNull_ReturnsFalse()
+    {
+        var renoDX = new RenoDX { OriginalName = null };
+
+        Assert.False(renoDX.IsExternalSourceMod);
+    }
+}

--- a/src/Restall.Tests/Infrastructure/EngineDetectionServiceTests.cs
+++ b/src/Restall.Tests/Infrastructure/EngineDetectionServiceTests.cs
@@ -1,0 +1,117 @@
+using Restall.Domain.Entities;
+using Restall.Infrastructure.Services;
+using Restall.Tests.TestUtilities;
+
+namespace Restall.Tests.Infrastructure;
+
+public sealed class EngineDetectionServiceTests
+{
+    // Verifies that Unreal Binaries/Win64 folders with executables are detected as Unreal.
+    [Fact]
+    public void DetectExecutablePathAndEngine_WhenUnrealBinariesExist_ReturnsUnrealBinariesFolder()
+    {
+        using var temp = new TempDirectory();
+        var binaries = temp.CreateDirectory(Path.Combine("Game", "Binaries", "Win64"));
+        temp.CreateFile(Path.Combine("Game", "Binaries", "Win64", "Game.exe"));
+        var sut = CreateSut();
+
+        var (executablePath, engine) = sut.DetectExecutablePathAndEngine(temp.GetPath("Game"));
+
+        Assert.Equal(binaries, executablePath);
+        Assert.Equal(Game.Engine.Unreal, engine);
+    }
+
+    // Verifies that Unreal detection prefers candidate folders containing Shipping executables.
+    [Fact]
+    public void DetectExecutablePathAndEngine_WhenMultipleUnrealBinariesExist_PrefersShippingExecutable()
+    {
+        using var temp = new TempDirectory();
+        temp.CreateFile(Path.Combine("Root", "First", "Binaries", "Win64", "Tool.exe"));
+        var shipping = temp.CreateDirectory(Path.Combine("Root", "Second", "Binaries", "Win64"));
+        temp.CreateFile(Path.Combine("Root", "Second", "Binaries", "Win64", "Game-Win64-Shipping.exe"));
+        var sut = CreateSut();
+
+        var (executablePath, engine) = sut.DetectExecutablePathAndEngine(temp.GetPath("Root"));
+
+        Assert.Equal(shipping, executablePath);
+        Assert.Equal(Game.Engine.Unreal, engine);
+    }
+
+    // Verifies that UnityPlayer.dll within the shallow search depth is detected as Unity.
+    [Fact]
+    public void DetectExecutablePathAndEngine_WhenUnityPlayerExists_ReturnsUnityFolder()
+    {
+        using var temp = new TempDirectory();
+        var unityFolder = temp.CreateDirectory(Path.Combine("Game", "Managed"));
+        temp.CreateFile(Path.Combine("Game", "Managed", "UnityPlayer.dll"));
+        var sut = CreateSut();
+
+        var (executablePath, engine) = sut.DetectExecutablePathAndEngine(temp.GetPath("Game"));
+
+        Assert.Equal(unityFolder, executablePath);
+        Assert.Equal(Game.Engine.Unity, engine);
+    }
+
+    // Verifies that preferred executable subfolders are chosen for unknown engines.
+    [Theory]
+    [InlineData("bin\\x64")]
+    [InlineData("bin\\x86")]
+    [InlineData("bin\\win64")]
+    public void DetectExecutablePathAndEngine_WhenPreferredExeFolderExists_ReturnsPreferredFolder(string subFolder)
+    {
+        using var temp = new TempDirectory();
+        var exeFolder = temp.CreateDirectory(Path.Combine("Game", subFolder));
+        temp.CreateFile(Path.Combine("Game", subFolder, "Game.exe"));
+        var sut = CreateSut();
+
+        var (executablePath, engine) = sut.DetectExecutablePathAndEngine(temp.GetPath("Game"));
+
+        Assert.Equal(exeFolder, executablePath);
+        Assert.Equal(Game.Engine.Unknown, engine);
+    }
+
+    // Verifies that shallow BFS finds an executable when preferred folders are absent.
+    [Fact]
+    public void DetectExecutablePathAndEngine_WhenOnlyShallowExeExists_ReturnsExeFolderAsUnknownEngine()
+    {
+        using var temp = new TempDirectory();
+        var exeFolder = temp.CreateDirectory(Path.Combine("Game", "Sub", "Content"));
+        temp.CreateFile(Path.Combine("Game", "Sub", "Content", "Game.exe"));
+        var sut = CreateSut();
+
+        var (executablePath, engine) = sut.DetectExecutablePathAndEngine(temp.GetPath("Game"));
+
+        Assert.Equal(exeFolder, executablePath);
+        Assert.Equal(Game.Engine.Unknown, engine);
+    }
+
+    // Verifies that non-game folders are skipped during executable folder discovery.
+    [Fact]
+    public void DetectExecutablePathAndEngine_WhenExeExistsOnlyInNonGameFolder_ReturnsNullUnknown()
+    {
+        using var temp = new TempDirectory();
+        temp.CreateFile(Path.Combine("Game", "_CommonRedist", "Helper.exe"));
+        var sut = CreateSut();
+
+        var (executablePath, engine) = sut.DetectExecutablePathAndEngine(temp.GetPath("Game"));
+
+        Assert.Null(executablePath);
+        Assert.Equal(Game.Engine.Unknown, engine);
+    }
+
+    // Verifies that folders without recognizable engine or executable files return null unknown.
+    [Fact]
+    public void DetectExecutablePathAndEngine_WhenNoEngineOrExecutableExists_ReturnsNullUnknown()
+    {
+        using var temp = new TempDirectory();
+        temp.CreateDirectory("Game");
+        var sut = CreateSut();
+
+        var (executablePath, engine) = sut.DetectExecutablePathAndEngine(temp.GetPath("Game"));
+
+        Assert.Null(executablePath);
+        Assert.Equal(Game.Engine.Unknown, engine);
+    }
+
+    private static EngineDetectionService CreateSut() => new(new NoOpLogService());
+}

--- a/src/Restall.Tests/Infrastructure/FileExtractionServiceTests.cs
+++ b/src/Restall.Tests/Infrastructure/FileExtractionServiceTests.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics;
+using Moq;
+using Restall.Application.Interfaces.Driven;
+using Restall.Infrastructure.Services;
+using Restall.Tests.TestUtilities;
+
+namespace Restall.Tests.Infrastructure;
+
+public sealed class FileExtractionServiceTests
+{
+    // Verifies that a missing extraction tool returns false and logs an informational message.
+    [Fact]
+    public void ExtractFiles_WhenExtractionToolIsMissing_ReturnsFalseAndLogsInfo()
+    {
+        using var temp = new TempDirectory();
+        var log = new Mock<ILogService>(MockBehavior.Loose);
+        var runner = new FakeExtractionProcessRunner();
+        runner.Enqueue(_ => new ExtractionProcessResult(1, string.Empty, string.Empty));
+        var sut = new FileExtractionService(log.Object, runner);
+
+        var result = sut.ExtractFiles(temp.GetPath("installer.exe"), ["ReShade64.dll"], temp.GetPath("extract"));
+
+        Assert.False(result);
+        log.Verify(x => x.LogInfo(
+            It.Is<string>(message => message.Contains("No extraction tool found")),
+            It.IsAny<string>()), Times.Once);
+    }
+
+    // Verifies that process start failures return false after the extraction tool was found.
+    [Fact]
+    public void ExtractFiles_WhenExtractionProcessCannotStart_ReturnsFalseAndLogsInfo()
+    {
+        using var temp = new TempDirectory();
+        var log = new Mock<ILogService>(MockBehavior.Loose);
+        var runner = new FakeExtractionProcessRunner();
+        runner.Enqueue(_ => new ExtractionProcessResult(0, "tar.exe", string.Empty));
+        runner.Enqueue(_ => null);
+        var sut = new FileExtractionService(log.Object, runner);
+
+        var result = sut.ExtractFiles(temp.GetPath("installer.exe"), ["ReShade64.dll"], temp.GetPath("extract"));
+
+        Assert.False(result);
+        log.Verify(x => x.LogInfo("Unable to start extraction process.", It.IsAny<string>()), Times.Once);
+    }
+
+    // Verifies that non-zero extraction exit codes return false and log stderr.
+    [Fact]
+    public void ExtractFiles_WhenExtractionProcessFails_ReturnsFalseAndLogsError()
+    {
+        using var temp = new TempDirectory();
+        var log = new Mock<ILogService>(MockBehavior.Loose);
+        var runner = new FakeExtractionProcessRunner();
+        runner.Enqueue(_ => new ExtractionProcessResult(0, "tar.exe", string.Empty));
+        runner.Enqueue(_ => new ExtractionProcessResult(2, string.Empty, "bad archive"));
+        var sut = new FileExtractionService(log.Object, runner);
+
+        var result = sut.ExtractFiles(temp.GetPath("installer.exe"), ["ReShade64.dll"], temp.GetPath("extract"));
+
+        Assert.False(result);
+        log.Verify(x => x.LogError(
+            It.Is<string>(message => message.Contains("Extraction failed with exit code 2") && message.Contains("bad archive")),
+            It.IsAny<Exception?>(),
+            It.IsAny<string>()), Times.Once);
+    }
+
+    // Verifies that successful extraction returns true and creates the destination directory.
+    [Fact]
+    public void ExtractFiles_WhenExtractionProcessSucceeds_ReturnsTrueAndCreatesDestination()
+    {
+        using var temp = new TempDirectory();
+        var destination = temp.GetPath("extract");
+        var archive = temp.GetPath("installer.exe");
+        var log = new Mock<ILogService>(MockBehavior.Loose);
+        var runner = new FakeExtractionProcessRunner();
+        runner.Enqueue(_ => new ExtractionProcessResult(0, "C:\\Tools\\tar.exe", string.Empty));
+        runner.Enqueue(_ => new ExtractionProcessResult(0, string.Empty, string.Empty));
+        var sut = new FileExtractionService(log.Object, runner);
+
+        var result = sut.ExtractFiles(archive, ["ReShade64.dll", "ReShade32.dll"], destination);
+
+        Assert.True(result);
+        Assert.True(Directory.Exists(destination));
+        Assert.Equal(2, runner.Calls.Count);
+        Assert.Equal("C:\\Tools\\tar.exe", runner.Calls[1].FileName);
+        Assert.Contains($"-xf \"{archive}\"", runner.Calls[1].Arguments);
+        Assert.Contains($"-C \"{destination}\"", runner.Calls[1].Arguments);
+        Assert.Contains("\"ReShade64.dll\"", runner.Calls[1].Arguments);
+        Assert.Contains("\"ReShade32.dll\"", runner.Calls[1].Arguments);
+    }
+
+    private sealed class FakeExtractionProcessRunner : IExtractionProcessRunner
+    {
+        private readonly Queue<Func<ProcessStartInfo, ExtractionProcessResult?>> _responses = [];
+
+        public List<ProcessStartInfo> Calls { get; } = [];
+
+        public void Enqueue(Func<ProcessStartInfo, ExtractionProcessResult?> response) => _responses.Enqueue(response);
+
+        public ExtractionProcessResult? Run(ProcessStartInfo startInfo)
+        {
+            Calls.Add(startInfo);
+            return _responses.Dequeue()(startInfo);
+        }
+    }
+}

--- a/src/Restall.Tests/Infrastructure/GameDetectionServiceTests.cs
+++ b/src/Restall.Tests/Infrastructure/GameDetectionServiceTests.cs
@@ -1,0 +1,172 @@
+using Moq;
+using Restall.Application.DTOs;
+using Restall.Application.Interfaces.Driven;
+using Restall.Domain.Entities;
+using Restall.Infrastructure.Services;
+using Restall.Tests.TestUtilities;
+
+namespace Restall.Tests.Infrastructure;
+
+public sealed class GameDetectionServiceTests
+{
+    // Verifies that game detection combines scanner results and enriches each valid game with engine data.
+    [Fact]
+    public async Task FindGamesAsync_CombinesScannerResultsAndSetsExecutablePathAndEngine()
+    {
+        var firstGame = CreateGame("Alpha", "c:\\games\\alpha", Game.Platform.Steam, "steam:1");
+        var secondGame = CreateGame("Beta", "c:\\games\\beta", Game.Platform.GOG, "gog:2");
+        var engineDetection = new Mock<IEngineDetectionService>(MockBehavior.Strict);
+        engineDetection.Setup(x => x.DetectExecutablePathAndEngine("c:\\games\\alpha"))
+            .Returns(("c:\\games\\alpha\\bin", Game.Engine.Unity));
+        engineDetection.Setup(x => x.DetectExecutablePathAndEngine("c:\\games\\beta"))
+            .Returns(("c:\\games\\beta\\bin", Game.Engine.Unreal));
+        var sut = CreateSut(engineDetection, new[]
+        {
+            Scanner(Game.Platform.Steam, firstGame),
+            Scanner(Game.Platform.GOG, secondGame)
+        });
+
+        var result = await sut.FindGamesAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(new[] { "Alpha", "Beta" }, result.Games.Select(g => g.Name));
+        Assert.Equal(Game.Engine.Unity, result.Games[0].EngineName);
+        Assert.Equal("c:\\games\\alpha\\bin", result.Games[0].ExecutablePath);
+        Assert.Equal(Game.Engine.Unreal, result.Games[1].EngineName);
+        Assert.Equal("c:\\games\\beta\\bin", result.Games[1].ExecutablePath);
+    }
+
+    // Verifies that scanner progress is reported once per scanner.
+    [Fact]
+    public async Task FindGamesAsync_ReportsProgressForEachScanner()
+    {
+        var game = CreateGame("Alpha", "c:\\games\\alpha", Game.Platform.Steam, "steam:1");
+        var reports = new List<GameScanProgressReportDto>();
+        var progress = new Progress<GameScanProgressReportDto>(reports.Add);
+        var engineDetection = new Mock<IEngineDetectionService>(MockBehavior.Strict);
+        engineDetection.Setup(x => x.DetectExecutablePathAndEngine("c:\\games\\alpha"))
+            .Returns(("c:\\games\\alpha", Game.Engine.Unknown));
+        var sut = CreateSut(engineDetection, new[]
+        {
+            Scanner(Game.Platform.Steam, game),
+            Scanner(Game.Platform.Epic)
+        });
+
+        await sut.FindGamesAsync(progress);
+
+        Assert.Equal(2, reports.Count);
+        Assert.Equal("Steam", reports[0].CompletedPlatform);
+        Assert.Equal(1, reports[0].ScannersCompleted);
+        Assert.Equal(2, reports[0].TotalScanners);
+        Assert.Equal("Epic", reports[1].CompletedPlatform);
+        Assert.Equal(2, reports[1].ScannersCompleted);
+    }
+
+    // Verifies that duplicate install folders are matched case-insensitively and prefer entries with platform ids.
+    [Fact]
+    public async Task FindGamesAsync_DeduplicatesInstallFoldersAndPrefersPlatformId()
+    {
+        var withoutId = CreateGame("Alpha No Id", "C:\\Games\\Alpha", Game.Platform.Unknown, platformId: null);
+        var withId = CreateGame("Alpha With Id", "c:\\games\\alpha", Game.Platform.Steam, "steam:1");
+        var engineDetection = new Mock<IEngineDetectionService>(MockBehavior.Strict);
+        engineDetection.Setup(x => x.DetectExecutablePathAndEngine("c:\\games\\alpha"))
+            .Returns(("c:\\games\\alpha", Game.Engine.Unknown));
+        var sut = CreateSut(engineDetection, new[]
+        {
+            Scanner(Game.Platform.Unknown, withoutId),
+            Scanner(Game.Platform.Steam, withId)
+        });
+
+        var result = await sut.FindGamesAsync();
+
+        var game = Assert.Single(result.Games);
+        Assert.Equal("Alpha With Id", game.Name);
+        Assert.Equal("steam:1", game.PlatformId);
+        engineDetection.Verify(x => x.DetectExecutablePathAndEngine(It.IsAny<string>()), Times.Once);
+    }
+
+    // Verifies that games without detected executable paths are filtered from results.
+    [Fact]
+    public async Task FindGamesAsync_FiltersGamesWithoutExecutablePath()
+    {
+        var valid = CreateGame("Valid", "c:\\games\\valid", Game.Platform.Steam, "steam:1");
+        var invalid = CreateGame("Invalid", "c:\\games\\invalid", Game.Platform.Steam, "steam:2");
+        var engineDetection = new Mock<IEngineDetectionService>(MockBehavior.Strict);
+        engineDetection.Setup(x => x.DetectExecutablePathAndEngine("c:\\games\\valid"))
+            .Returns(("c:\\games\\valid", Game.Engine.Unknown));
+        engineDetection.Setup(x => x.DetectExecutablePathAndEngine("c:\\games\\invalid"))
+            .Returns((null, Game.Engine.Unknown));
+        var sut = CreateSut(engineDetection, new[] { Scanner(Game.Platform.Steam, valid, invalid) });
+
+        var result = await sut.FindGamesAsync();
+
+        var game = Assert.Single(result.Games);
+        Assert.Equal("Valid", game.Name);
+        Assert.True(result.IsSuccess);
+    }
+
+    // Verifies that scanner warning messages are aggregated in the final scan result.
+    [Fact]
+    public async Task FindGamesAsync_AggregatesScannerMessages()
+    {
+        var game = CreateGame("Alpha", "c:\\games\\alpha", Game.Platform.Steam, "steam:1");
+        var engineDetection = new Mock<IEngineDetectionService>(MockBehavior.Strict);
+        engineDetection.Setup(x => x.DetectExecutablePathAndEngine("c:\\games\\alpha"))
+            .Returns(("c:\\games\\alpha", Game.Engine.Unknown));
+        var sut = CreateSut(engineDetection, new[]
+        {
+            Scanner(Game.Platform.Steam, "Steam warning", game),
+            Scanner(Game.Platform.Epic, "Epic warning")
+        });
+
+        var result = await sut.FindGamesAsync();
+
+        Assert.Equal("Steam warning; Epic warning", result.Message);
+    }
+
+    // Verifies that scanner exceptions are converted into a safe failure result.
+    [Fact]
+    public async Task FindGamesAsync_WhenScannerThrows_ReturnsFailureWithGenericMessage()
+    {
+        var scanner = new Mock<IPlatformScannerService>(MockBehavior.Strict);
+        scanner.SetupGet(x => x.Platform).Returns(Game.Platform.Steam);
+        scanner.Setup(x => x.ScanAsync()).ThrowsAsync(new InvalidOperationException("boom"));
+        var engineDetection = new Mock<IEngineDetectionService>(MockBehavior.Strict);
+        var sut = CreateSut(engineDetection, new[] { scanner.Object });
+
+        var result = await sut.FindGamesAsync();
+
+        Assert.False(result.IsSuccess);
+        Assert.Empty(result.Games);
+        Assert.Equal("Failed to scan game libraries. Please try rescanning.", result.Message);
+    }
+
+    private static GameDetectionService CreateSut(
+        Mock<IEngineDetectionService> engineDetection,
+        IEnumerable<IPlatformScannerService> scanners) =>
+        new(new NoOpLogService(), scanners, engineDetection.Object);
+
+    private static IPlatformScannerService Scanner(Game.Platform platform, params Game[] games) =>
+        Scanner(platform, message: null, games);
+
+    private static IPlatformScannerService Scanner(Game.Platform platform, string? message, params Game[] games)
+    {
+        var scanner = new Mock<IPlatformScannerService>(MockBehavior.Strict);
+        scanner.SetupGet(x => x.Platform).Returns(platform);
+        scanner.Setup(x => x.ScanAsync()).ReturnsAsync(new GameScanResultDto(
+            platform,
+            games,
+            games.Length > 0,
+            message));
+        return scanner.Object;
+    }
+
+    private static Game CreateGame(string name, string installFolder, Game.Platform platform, string? platformId) =>
+        new()
+        {
+            Name = name,
+            InstallFolder = installFolder,
+            PlatformName = platform,
+            PlatformId = platformId
+        };
+}

--- a/src/Restall.Tests/Infrastructure/GameScanHelperTests.cs
+++ b/src/Restall.Tests/Infrastructure/GameScanHelperTests.cs
@@ -1,0 +1,111 @@
+using Restall.Infrastructure.Helpers;
+
+namespace Restall.Tests.Infrastructure;
+
+public sealed class GameScanHelperTests
+{
+    // Verifies that null and empty paths are treated as missing values.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void NormalizePath_WhenPathIsNullOrEmpty_ReturnsNull(string? path)
+    {
+        var result = GameScanHelper.NormalizePath(path);
+
+        Assert.Null(result);
+    }
+
+    // Verifies that path separators, whitespace and trailing separators are normalized.
+    [Fact]
+    public void NormalizePath_WhenPathHasAltSeparatorsAndTrailingSlash_ReturnsNormalizedPath()
+    {
+        var result = GameScanHelper.NormalizePath("  C:/Games/Alpha/  ");
+
+        Assert.Equal($"C:{Path.DirectorySeparatorChar}Games{Path.DirectorySeparatorChar}Alpha", result);
+    }
+
+    // Verifies that VDF values are extracted case-insensitively.
+    [Fact]
+    public void ExtractVdfValue_WhenKeyExists_ReturnsValueIgnoringKeyCase()
+    {
+        const string vdf = "\"AppState\"\n{\n  \"name\" \"Alpha Game\"\n  \"installdir\" \"Alpha Folder\"\n}";
+
+        Assert.Equal("Alpha Game", GameScanHelper.ExtractVdfValue(vdf, "NAME"));
+        Assert.Equal("Alpha Folder", GameScanHelper.ExtractVdfValue(vdf, "InstallDir"));
+    }
+
+    // Verifies that missing VDF keys return null instead of a false match.
+    [Fact]
+    public void ExtractVdfValue_WhenKeyIsMissing_ReturnsNull()
+    {
+        const string vdf = "\"AppState\"\n{\n  \"name\" \"Alpha Game\"\n}";
+
+        var result = GameScanHelper.ExtractVdfValue(vdf, "appid");
+
+        Assert.Null(result);
+    }
+
+    // Verifies that JSON string extraction unescapes and normalizes installer paths.
+    [Fact]
+    public void ExtractJsonString_WhenPathContainsEscapedBackslashes_ReturnsNormalizedPath()
+    {
+        const string json = "{ \"InstallLocation\": \"C:\\\\Games\\\\Alpha\\\\\" }";
+
+        var result = GameScanHelper.ExtractJsonString(json, "InstallLocation");
+
+        Assert.Equal($"C:{Path.DirectorySeparatorChar}Games{Path.DirectorySeparatorChar}Alpha", result);
+    }
+
+    // Verifies that missing JSON keys return null.
+    [Fact]
+    public void ExtractJsonString_WhenKeyIsMissing_ReturnsNull()
+    {
+        const string json = "{ \"DisplayName\": \"Alpha Game\" }";
+
+        var result = GameScanHelper.ExtractJsonString(json, "InstallLocation");
+
+        Assert.Null(result);
+    }
+
+    // Verifies that launcher tool entries and known suffixes are filtered out as non-games.
+    [Theory]
+    [InlineData("Steamworks Common Redistributables")]
+    [InlineData("Cool _CommonRedist package")]
+    [InlineData("UE_5.3")]
+    [InlineData("Alpha Dedicated Server")]
+    [InlineData("Alpha Demo")]
+    [InlineData("Alpha Playtest")]
+    public void NonGame_WhenNameMatchesKnownToolOrSuffix_ReturnsTrue(string name)
+    {
+        var result = GameScanHelper.NonGame(name);
+
+        Assert.True(result);
+    }
+
+    // Verifies that regular game names are not rejected by weak substring matches.
+    [Theory]
+    [InlineData("Alpha Game")]
+    [InlineData("Demon Souls")]
+    [InlineData("BetaMax Adventure")]
+    public void NonGame_WhenNameIsRegularGame_ReturnsFalse(string name)
+    {
+        var result = GameScanHelper.NonGame(name);
+
+        Assert.False(result);
+    }
+
+    // Verifies that preferred executable folders stay in the expected search order.
+    [Fact]
+    public void GetPreferredExeSubFolders_ReturnsKnownSearchOrder()
+    {
+        var result = GameScanHelper.GetPreferredExeSubFolders();
+
+        Assert.Equal(
+            [
+                Path.Combine("bin", "x64"),
+                Path.Combine("bin", "x86"),
+                Path.Combine("bin", "win64")
+            ],
+            result);
+    }
+}

--- a/src/Restall.Tests/Infrastructure/InfrastructureServiceCollectionExtensionsTests.cs
+++ b/src/Restall.Tests/Infrastructure/InfrastructureServiceCollectionExtensionsTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Restall.Application.Interfaces.Driven;
+using Restall.Application.Interfaces.Driving;
+using Restall.Infrastructure.Extensions;
+using Restall.Infrastructure.Services;
+
+namespace Restall.Tests.Infrastructure;
+
+public sealed class InfrastructureServiceCollectionExtensionsTests
+{
+    // Verifies that infrastructure registrations use the expected lifetimes for shared services.
+    [Fact]
+    public void AddInfrastructureServices_RegistersExpectedSingletonsAndTransients()
+    {
+        var services = CreateServiceCollection();
+
+        services.AddInfrastructureServices();
+
+        AssertLifetime<IPathService>(services, ServiceLifetime.Singleton);
+        AssertLifetime<ILogService>(services, ServiceLifetime.Singleton);
+        AssertLifetime<IParseService>(services, ServiceLifetime.Singleton);
+        AssertLifetime<IVersionCatalog>(services, ServiceLifetime.Singleton);
+        AssertLifetime<IModCatalog>(services, ServiceLifetime.Singleton);
+        AssertLifetime<IRefreshLibraryUseCase>(services, ServiceLifetime.Transient);
+        AssertLifetime<ILightRefreshLibraryUseCase>(services, ServiceLifetime.Transient);
+        AssertLifetime<IModInstallService>(services, ServiceLifetime.Transient);
+        AssertLifetime<IFileExtractionService>(services, ServiceLifetime.Transient);
+        AssertLifetime<IInstallReShadeUseCase>(services, ServiceLifetime.Transient);
+        AssertLifetime<IInstallRenoDXUseCase>(services, ServiceLifetime.Transient);
+        AssertLifetime<IUninstallReShadeUseCase>(services, ServiceLifetime.Transient);
+        AssertLifetime<IUninstallRenoDXUseCase>(services, ServiceLifetime.Transient);
+        AssertLifetime<IModManagementFacade>(services, ServiceLifetime.Transient);
+        Assert.Equal(5, services.Count(x => x.ServiceType == typeof(IPlatformScannerService) && x.Lifetime == ServiceLifetime.Singleton));
+    }
+
+    // Verifies that the registered service provider can resolve representative services.
+    [Fact]
+    public void AddInfrastructureServices_BuildsProviderAndResolvesRepresentativeServices()
+    {
+        var services = CreateServiceCollection();
+        services.AddInfrastructureServices();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        Assert.IsType<PathService>(provider.GetRequiredService<IPathService>());
+        Assert.Same(provider.GetRequiredService<IVersionCatalog>(), provider.GetRequiredService<IVersionCatalog>());
+        Assert.NotSame(provider.GetRequiredService<IFileExtractionService>(), provider.GetRequiredService<IFileExtractionService>());
+        Assert.Equal(5, provider.GetServices<IPlatformScannerService>().Count());
+        Assert.NotNull(provider.GetRequiredService<IModDownloadService>());
+    }
+
+    private static ServiceCollection CreateServiceCollection()
+    {
+        var services = new ServiceCollection();
+        var configuration = new Mock<IConfiguration>(MockBehavior.Loose);
+        configuration.Setup(x => x["SteamGridDBApiKey:ApiKey"]).Returns((string?)null);
+        services.AddSingleton(configuration.Object);
+        return services;
+    }
+
+    private static void AssertLifetime<TService>(IServiceCollection services, ServiceLifetime expectedLifetime)
+    {
+        var descriptor = Assert.Single(services, x => x.ServiceType == typeof(TService));
+        Assert.Equal(expectedLifetime, descriptor.Lifetime);
+    }
+}

--- a/src/Restall.Tests/Infrastructure/LogServiceTests.cs
+++ b/src/Restall.Tests/Infrastructure/LogServiceTests.cs
@@ -1,0 +1,52 @@
+using Moq;
+using Restall.Application.Interfaces.Driven;
+using Restall.Infrastructure.Services;
+using Restall.Tests.TestUtilities;
+
+namespace Restall.Tests.Infrastructure;
+
+public sealed class LogServiceTests
+{
+    // Verifies that sync logging writes info, warning, error and exception text to the default log file.
+    [Fact]
+    public void SyncLogMethods_WriteExpectedEntriesToDefaultLogFile()
+    {
+        using var temp = new TempDirectory();
+        var sut = CreateService(temp.GetPath("logs"));
+
+        sut.LogInfo("Info message");
+        sut.LogWarning("Warning message");
+        sut.LogError("Error message", new InvalidOperationException("Boom"));
+
+        var contents = File.ReadAllText(temp.GetPath("logs", "restall_log.txt"));
+        Assert.Contains("| Info | Info message", contents);
+        Assert.Contains("| Warning | Warning message", contents);
+        Assert.Contains("| Error | Error message || Boom", contents);
+    }
+
+    // Verifies that async logging creates the log directory and writes to a custom file.
+    [Fact]
+    public async Task AsyncLogMethods_WriteExpectedEntriesToCustomLogFileAndCreateDirectory()
+    {
+        using var temp = new TempDirectory();
+        var logDirectory = temp.GetPath("logs");
+        var sut = CreateService(logDirectory);
+
+        await sut.LogInfoAsync("Info message", "custom.txt");
+        await sut.LogWarningAsync("Warning message", "custom.txt");
+        await sut.LogErrorAsync("Error message", new InvalidOperationException("Boom"), "custom.txt");
+
+        var contents = File.ReadAllText(Path.Combine(logDirectory, "custom.txt"));
+        Assert.True(Directory.Exists(logDirectory));
+        Assert.Contains("| Info | Info message", contents);
+        Assert.Contains("| Warning | Warning message", contents);
+        Assert.Contains("| Error | Error message || Boom", contents);
+    }
+
+    private static LogService CreateService(string logDirectory)
+    {
+        var pathService = new Mock<IPathService>(MockBehavior.Strict);
+        pathService.Setup(x => x.GetDefaultLogPath()).Returns(logDirectory);
+        return new LogService(pathService.Object);
+    }
+}

--- a/src/Restall.Tests/Infrastructure/ModCatalogTests.cs
+++ b/src/Restall.Tests/Infrastructure/ModCatalogTests.cs
@@ -1,0 +1,71 @@
+using Moq;
+using Restall.Application.DTOs;
+using Restall.Application.Interfaces.Driven;
+using Restall.Infrastructure.Stores;
+
+namespace Restall.Tests.Infrastructure;
+
+public sealed class ModCatalogTests
+{
+    // Verifies that mod catalog getters are empty before the first fetch.
+    [Fact]
+    public void Getters_WhenCatalogHasNotFetched_ReturnEmptyLists()
+    {
+        var parse = new Mock<IParseService>(MockBehavior.Strict);
+        var sut = new ModCatalog(parse.Object);
+
+        Assert.Empty(sut.GetRenoDXWikiMods());
+        Assert.Empty(sut.GetRenoDXGenericWikiMods());
+    }
+
+    // Verifies that FetchModsAsync stores both specific and generic RenoDX wiki mods.
+    [Fact]
+    public async Task FetchModsAsync_PopulatesSpecificAndGenericModLists()
+    {
+        var parse = new Mock<IParseService>(MockBehavior.Strict);
+        var wikiMod = new RenoDXModInfoDto(
+            "Game",
+            DiscordUrl: null,
+            SnapshotUrl64: "https://example.test/renodx-game.addon64",
+            SnapshotUrl32: null,
+            NexusUrl: null,
+            Maintainer: "Maintainer",
+            Notes: null,
+            Status: ":white_check_mark:");
+        var genericMod = new RenoDXGenericModInfoDto("Generic Unreal", ":white_check_mark:", SupportedEngine.Unreal);
+        parse.Setup(x => x.FetchRenoDXWikiModsAsync())
+            .ReturnsAsync(new RenoDXWikiParseResultDto(new[] { wikiMod }, new[] { genericMod }));
+        var sut = new ModCatalog(parse.Object);
+
+        await sut.FetchModsAsync();
+
+        Assert.Equal(new[] { wikiMod }, sut.GetRenoDXWikiMods());
+        Assert.Equal(new[] { genericMod }, sut.GetRenoDXGenericWikiMods());
+    }
+
+    // Verifies that a second fetch replaces stale mod catalog data.
+    [Fact]
+    public async Task FetchModsAsync_WhenCalledAgain_ReplacesPreviousLists()
+    {
+        var parse = new Mock<IParseService>(MockBehavior.Strict);
+        var firstMod = new RenoDXModInfoDto(
+            "First",
+            DiscordUrl: null,
+            SnapshotUrl64: "https://example.test/renodx-first.addon64",
+            SnapshotUrl32: null,
+            NexusUrl: null,
+            Maintainer: "Maintainer",
+            Notes: null,
+            Status: ":white_check_mark:");
+        parse.SetupSequence(x => x.FetchRenoDXWikiModsAsync())
+            .ReturnsAsync(new RenoDXWikiParseResultDto(new[] { firstMod }, Array.Empty<RenoDXGenericModInfoDto>()))
+            .ReturnsAsync(new RenoDXWikiParseResultDto(Array.Empty<RenoDXModInfoDto>(), Array.Empty<RenoDXGenericModInfoDto>()));
+        var sut = new ModCatalog(parse.Object);
+
+        await sut.FetchModsAsync();
+        await sut.FetchModsAsync();
+
+        Assert.Empty(sut.GetRenoDXWikiMods());
+        Assert.Empty(sut.GetRenoDXGenericWikiMods());
+    }
+}

--- a/src/Restall.Tests/Infrastructure/ModDownloadServiceTests.cs
+++ b/src/Restall.Tests/Infrastructure/ModDownloadServiceTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using Moq;
+using Restall.Application.DTOs;
+using Restall.Application.Interfaces.Driven;
+using Restall.Domain.Entities;
+using Restall.Infrastructure.Services;
+using Restall.Tests.TestUtilities;
+
+namespace Restall.Tests.Infrastructure;
+
+public sealed class ModDownloadServiceTests
+{
+    // Verifies that ReShade downloads use the expected URL and write the installer cache file.
+    [Fact]
+    public async Task DownloadReShadeAsync_DownloadsExpectedInstallerToCache()
+    {
+        using var temp = new TempDirectory();
+        var bytes = new byte[] { 1, 2, 3 };
+        var handler = new FakeHttpMessageHandler(_ => FakeHttpMessageHandler.BytesResponse(bytes));
+        var sut = CreateService(temp, handler);
+        var progress = new RecordingProgress();
+
+        var result = await sut.DownloadReShadeAsync(ReShade.Branch.Stable, "6.5.0", progress);
+
+        Assert.True(result);
+        Assert.Equal(bytes, File.ReadAllBytes(temp.GetPath("reshade", "Stable", "ReShade_Setup_6.5.0_Addon.exe")));
+        Assert.Equal("https://reshade.me/downloads/ReShade_Setup_6.5.0_Addon.exe", handler.RequestUris.Single()!.ToString());
+        Assert.Contains(progress.Reports, x => x.Filename == "ReShade_Setup_6.5.0_Addon.exe" && x.PercentComplete == 100);
+    }
+
+    // Verifies that Unity RenoDX downloads use the Unity endpoint and Snapshot cache.
+    [Fact]
+    public async Task DownloadUnityRenoDXAsync_DownloadsUnityAddonToSnapshotCache()
+    {
+        using var temp = new TempDirectory();
+        var bytes = new byte[] { 4, 5, 6 };
+        var handler = new FakeHttpMessageHandler(_ => FakeHttpMessageHandler.BytesResponse(bytes));
+        var sut = CreateService(temp, handler);
+
+        var result = await sut.DownloadUnityRenoDXAsync("renodx-unityengine.addon64");
+
+        Assert.True(result);
+        Assert.Equal(bytes, File.ReadAllBytes(temp.GetPath("renodx", "Snapshot", "renodx-unityengine.addon64")));
+        Assert.Equal("https://notvoosh.github.io/renodx-unity/renodx-unityengine.addon64", handler.RequestUris.Single()!.ToString());
+    }
+
+    // Verifies that RenoDX automated branches build the expected URLs and cache filenames.
+    [Theory]
+    [InlineData(RenoDX.Branch.Wiki, null, null, "https://example.test/releases/renodx-game.addon64", "Wiki", "renodx-game.addon64", "https://example.test/releases/renodx-game.addon64")]
+    [InlineData(RenoDX.Branch.Snapshot, "renodx-unrealengine.addon64", null, null, "Snapshot", "renodx-unrealengine.addon64", "https://github.com/clshortfuse/renodx/releases/download/snapshot/renodx-unrealengine.addon64")]
+    [InlineData(RenoDX.Branch.Nightly, "renodx-unrealengine.addon32", "20240203", null, "Nightly", "renodx-unrealengine.addon32", "https://github.com/clshortfuse/renodx/releases/download/nightly-20240203/renodx-unrealengine.addon32")]
+    public async Task DownloadRenoDXAsync_WhenBranchSupportsDownload_DownloadsExpectedFile(
+        RenoDX.Branch branch,
+        string? addonFileName,
+        string? version,
+        string? wikiSnapshotUrl,
+        string cacheBranch,
+        string expectedFileName,
+        string expectedUrl)
+    {
+        using var temp = new TempDirectory();
+        var bytes = new byte[] { 7, 8, 9 };
+        var handler = new FakeHttpMessageHandler(_ => FakeHttpMessageHandler.BytesResponse(bytes));
+        var sut = CreateService(temp, handler);
+
+        var result = await sut.DownloadRenoDXAsync(branch, addonFileName, version, wikiSnapshotUrl);
+
+        Assert.True(result);
+        Assert.Equal(bytes, File.ReadAllBytes(temp.GetPath("renodx", cacheBranch, expectedFileName)));
+        Assert.Equal(expectedUrl, handler.RequestUris.Single()!.ToString());
+    }
+
+    // Verifies that invalid RenoDX branch input returns false before making HTTP requests.
+    [Theory]
+    [InlineData(RenoDX.Branch.Wiki, null, null, null)]
+    [InlineData(RenoDX.Branch.Snapshot, null, null, null)]
+    [InlineData(RenoDX.Branch.Nightly, "renodx-unrealengine.addon64", null, null)]
+    [InlineData(RenoDX.Branch.Nightly, null, "20240203", null)]
+    [InlineData(RenoDX.Branch.Nexus, "renodx-unrealengine.addon64", "20240203", null)]
+    public async Task DownloadRenoDXAsync_WhenInputCannotBuildDownload_ReturnsFalseWithoutHttp(
+        RenoDX.Branch branch,
+        string? addonFileName,
+        string? version,
+        string? wikiSnapshotUrl)
+    {
+        using var temp = new TempDirectory();
+        var handler = new FakeHttpMessageHandler(_ => throw new InvalidOperationException("HTTP should not be called"));
+        var sut = CreateService(temp, handler);
+
+        var result = await sut.DownloadRenoDXAsync(branch, addonFileName, version, wikiSnapshotUrl);
+
+        Assert.False(result);
+        Assert.Empty(handler.RequestUris);
+    }
+
+    // Verifies that existing cache files skip HTTP and report completed progress.
+    [Fact]
+    public async Task DownloadReShadeAsync_WhenCacheFileAlreadyExists_SkipsHttpAndReportsComplete()
+    {
+        using var temp = new TempDirectory();
+        temp.CreateFile(Path.Combine("reshade", "Stable", "ReShade_Setup_6.5.0_Addon.exe"), "cached");
+        var handler = new FakeHttpMessageHandler(_ => throw new InvalidOperationException("HTTP should not be called"));
+        var sut = CreateService(temp, handler);
+        var progress = new RecordingProgress();
+
+        var result = await sut.DownloadReShadeAsync(ReShade.Branch.Stable, "6.5.0", progress);
+
+        Assert.True(result);
+        Assert.Equal("cached", File.ReadAllText(temp.GetPath("reshade", "Stable", "ReShade_Setup_6.5.0_Addon.exe")));
+        Assert.Empty(handler.RequestUris);
+        Assert.Contains(progress.Reports, x => x.Filename == "ReShade_Setup_6.5.0_Addon.exe" && x.PercentComplete == 100);
+    }
+
+    // Verifies that HTTP failures return false and do not leave a successful cache file.
+    [Fact]
+    public async Task DownloadReShadeAsync_WhenHttpFails_ReturnsFalse()
+    {
+        using var temp = new TempDirectory();
+        var handler = new FakeHttpMessageHandler(_ => FakeHttpMessageHandler.TextResponse("fail", HttpStatusCode.InternalServerError));
+        var sut = CreateService(temp, handler);
+
+        var result = await sut.DownloadReShadeAsync(ReShade.Branch.Stable, "6.5.0");
+
+        Assert.False(result);
+        Assert.False(File.Exists(temp.GetPath("reshade", "Stable", "ReShade_Setup_6.5.0_Addon.exe")));
+    }
+
+    private static ModDownloadService CreateService(TempDirectory temp, FakeHttpMessageHandler handler)
+    {
+        var pathService = new Mock<IPathService>(MockBehavior.Strict);
+        pathService.Setup(x => x.GetReShadeInstallerFilePath(It.IsAny<ReShade.Branch>(), It.IsAny<string>()))
+            .Returns((ReShade.Branch branch, string version) => temp.GetPath("reshade", branch.ToString(), $"ReShade_Setup_{version}_Addon.exe"));
+        pathService.Setup(x => x.GetRenoDXDownloadCachePath(It.IsAny<RenoDX.Branch>()))
+            .Returns((RenoDX.Branch branch) => temp.GetPath("renodx", branch.ToString()));
+
+        return new ModDownloadService(new HttpClient(handler), pathService.Object, new NoOpLogService());
+    }
+
+    private sealed class RecordingProgress : IProgress<DownloadProgressReportDto>
+    {
+        public List<DownloadProgressReportDto> Reports { get; } = [];
+
+        public void Report(DownloadProgressReportDto value) => Reports.Add(value);
+    }
+}

--- a/src/Restall.Tests/Infrastructure/ModInstallServiceTests.cs
+++ b/src/Restall.Tests/Infrastructure/ModInstallServiceTests.cs
@@ -1,0 +1,279 @@
+using Restall.Domain.Entities;
+using Restall.Infrastructure.Services;
+using Restall.Tests.TestUtilities;
+
+namespace Restall.Tests.Infrastructure;
+
+public sealed class ModInstallServiceTests
+{
+    [Fact]
+    public async Task InstallModAsync_WhenInstallingReShade_CopiesFileAndUpdatesGameState()
+    {
+        using var temp = new TempDirectory();
+        var gameDir = temp.CreateDirectory("game");
+        var sourcePath = temp.CreateFile(Path.Combine("cache", "ReShade64.dll"), "reshade-content");
+        var game = CreateGame(gameDir);
+        var reShade = new ReShade
+        {
+            SelectedFilename = "dxgi.dll",
+            Version = "6.5.0"
+        };
+        var sut = CreateSut();
+
+        var result = await sut.InstallModAsync(game, reShade, sourcePath);
+
+        Assert.True(result.IsSuccess);
+        Assert.Same(game, result.UpdatedGame);
+        Assert.Same(reShade, game.ReShade);
+        Assert.Equal("reshade-content", File.ReadAllText(Path.Combine(gameDir, "dxgi.dll")));
+    }
+
+    [Fact]
+    public async Task InstallModAsync_WhenReplacingExistingReShade_RemovesOldFileAndCopiesNewFile()
+    {
+        using var temp = new TempDirectory();
+        var gameDir = temp.CreateDirectory("game");
+        var sourcePath = temp.CreateFile(Path.Combine("cache", "ReShade64.dll"), "new-content");
+        var oldPath = temp.CreateFile(Path.Combine("game", "old.dll"), "old-content");
+        var game = CreateGame(gameDir);
+        game.ReShade = new ReShade { SelectedFilename = "old.dll", Version = "6.4.0" };
+        var reShade = new ReShade
+        {
+            SelectedFilename = "dxgi.dll",
+            Version = "6.5.0"
+        };
+        var sut = CreateSut();
+
+        var result = await sut.InstallModAsync(game, reShade, sourcePath);
+
+        Assert.True(result.IsSuccess);
+        Assert.False(File.Exists(oldPath));
+        Assert.Equal("new-content", File.ReadAllText(Path.Combine(gameDir, "dxgi.dll")));
+        Assert.Same(reShade, game.ReShade);
+    }
+
+    [Fact]
+    public async Task InstallModAsync_WhenReShadeSourceIsMissing_ReturnsFailure()
+    {
+        using var temp = new TempDirectory();
+        var gameDir = temp.CreateDirectory("game");
+        var game = CreateGame(gameDir);
+        var reShade = new ReShade { SelectedFilename = "dxgi.dll" };
+        var sut = CreateSut();
+
+        var result = await sut.InstallModAsync(game, reShade, temp.GetPath("missing", "ReShade64.dll"));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Install failed. Disk may be full or the game folder was moved.", result.Message);
+        Assert.Null(game.ReShade);
+        Assert.False(File.Exists(Path.Combine(gameDir, "dxgi.dll")));
+    }
+
+    [Fact]
+    public async Task InstallModAsync_WhenInstallingRenoDX_CopiesFileAndUpdatesGameState()
+    {
+        using var temp = new TempDirectory();
+        var gameDir = temp.CreateDirectory("game");
+        var sourcePath = temp.CreateFile(Path.Combine("cache", "renodx-game.addon64"), "renodx-content");
+        var game = CreateGame(gameDir);
+        var renoDX = new RenoDX
+        {
+            OriginalName = "renodx-game.addon64",
+            SelectedName = "renodx-game.addon64",
+            Version = "20240101"
+        };
+        var sut = CreateSut();
+
+        var result = await sut.InstallModAsync(game, renoDX, sourcePath);
+
+        Assert.True(result.IsSuccess);
+        Assert.Same(game, result.UpdatedGame);
+        Assert.Same(renoDX, game.RenoDX);
+        Assert.Equal("renodx-content", File.ReadAllText(Path.Combine(gameDir, "renodx-game.addon64")));
+    }
+
+    [Fact]
+    public async Task InstallModAsync_WhenRenoDXOriginalNameDiffersFromSelectedName_CopiesSelectedFile()
+    {
+        using var temp = new TempDirectory();
+        var gameDir = temp.CreateDirectory("game");
+        var sourcePath = temp.CreateFile(Path.Combine("cache", "renodx-new.addon64"), "new-renodx");
+        var originalPath = temp.CreateFile(Path.Combine("game", "renodx-old.addon64"), "not-a-pe-file");
+        var game = CreateGame(gameDir);
+        var renoDX = new RenoDX
+        {
+            OriginalName = "renodx-old.addon64",
+            SelectedName = "renodx-new.addon64",
+            Version = "20240202"
+        };
+        var sut = CreateSut();
+
+        var result = await sut.InstallModAsync(game, renoDX, sourcePath);
+
+        Assert.True(result.IsSuccess);
+        Assert.True(File.Exists(originalPath));
+        Assert.Equal("new-renodx", File.ReadAllText(Path.Combine(gameDir, "renodx-new.addon64")));
+        Assert.Same(renoDX, game.RenoDX);
+    }
+
+    [Fact]
+    public async Task InstallModAsync_WhenRenoDXSourceIsMissing_ReturnsFailure()
+    {
+        using var temp = new TempDirectory();
+        var gameDir = temp.CreateDirectory("game");
+        var game = CreateGame(gameDir);
+        var renoDX = new RenoDX
+        {
+            OriginalName = "renodx-game.addon64",
+            SelectedName = "renodx-game.addon64"
+        };
+        var sut = CreateSut();
+
+        var result = await sut.InstallModAsync(game, renoDX, temp.GetPath("missing", "renodx-game.addon64"));
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Install failed. Disk may be full or the game folder was moved.", result.Message);
+        Assert.Null(game.RenoDX);
+        Assert.False(File.Exists(Path.Combine(gameDir, "renodx-game.addon64")));
+    }
+
+    [Fact]
+    public async Task UninstallReShadeAsync_WhenFileExists_RemovesFileAndClearsGameState()
+    {
+        using var temp = new TempDirectory();
+        var gameDir = temp.CreateDirectory("game");
+        var installedPath = temp.CreateFile(Path.Combine("game", "dxgi.dll"), "reshade-content");
+        var game = CreateGame(gameDir);
+        game.ReShade = new ReShade { SelectedFilename = "dxgi.dll" };
+        var sut = CreateSut();
+
+        var result = await sut.UninstallReShadeAsync(game);
+
+        Assert.True(result.IsSuccess);
+        Assert.False(File.Exists(installedPath));
+        Assert.Null(game.ReShade);
+    }
+
+    [Fact]
+    public async Task UninstallReShadeAsync_WhenFileIsMissing_ReturnsFailureAndPromptsForDeepScan()
+    {
+        using var temp = new TempDirectory();
+        var game = CreateGame(temp.CreateDirectory("game"));
+        game.ReShade = new ReShade { SelectedFilename = "dxgi.dll" };
+        var sut = CreateSut();
+
+        var result = await sut.UninstallReShadeAsync(game);
+
+        Assert.False(result.IsSuccess);
+        Assert.True(result.ShouldPromptForDeepScan);
+        Assert.Null(game.ReShade);
+    }
+
+    [Fact]
+    public async Task UninstallRenoDXAsync_WhenFileIsMissing_ReturnsFailureAndPromptsForDeepScan()
+    {
+        using var temp = new TempDirectory();
+        var game = CreateGame(temp.CreateDirectory("game"));
+        game.RenoDX = new RenoDX { SelectedName = "renodx-game.addon64" };
+        var sut = CreateSut();
+
+        var result = await sut.UninstallRenoDXAsync(game);
+
+        Assert.False(result.IsSuccess);
+        Assert.True(result.ShouldPromptForDeepScan);
+        Assert.Null(game.RenoDX);
+    }
+
+    [Fact]
+    public async Task UninstallRenoDXAsync_WhenFileIsNotVerifiedRenoDX_DoesNotDeleteFileButClearsGameState()
+    {
+        using var temp = new TempDirectory();
+        var gameDir = temp.CreateDirectory("game");
+        var installedPath = temp.CreateFile(Path.Combine("game", "renodx-game.addon64"), "not-a-pe-file");
+        var game = CreateGame(gameDir);
+        game.RenoDX = new RenoDX { SelectedName = "renodx-game.addon64" };
+        var sut = CreateSut();
+
+        var result = await sut.UninstallRenoDXAsync(game);
+
+        Assert.False(result.IsSuccess);
+        Assert.True(result.ShouldPromptForDeepScan);
+        Assert.True(File.Exists(installedPath));
+        Assert.Null(game.RenoDX);
+    }
+
+    [Fact]
+    public async Task RemoveAllReShadeFiles_WhenDirectoryIsEmpty_ClearsGameState()
+    {
+        using var temp = new TempDirectory();
+        var game = CreateGame(temp.CreateDirectory("game"));
+        game.ReShade = new ReShade { SelectedFilename = "dxgi.dll" };
+        var sut = CreateSut();
+
+        var result = await sut.RemoveAllReShadeFiles(game);
+
+        Assert.Same(game, result);
+        Assert.Null(game.ReShade);
+    }
+
+    [Fact]
+    public async Task RemoveAllReShadeFiles_WhenFilesAreNotVerifiedReShade_LeavesFilesAndClearsGameState()
+    {
+        using var temp = new TempDirectory();
+        var gameDir = temp.CreateDirectory("game");
+        var dllPath = temp.CreateFile(Path.Combine("game", "dxgi.dll"), "not-a-pe-file");
+        var asiPath = temp.CreateFile(Path.Combine("game", "plugin.asi"), "not-a-pe-file");
+        var game = CreateGame(gameDir);
+        game.ReShade = new ReShade { SelectedFilename = "dxgi.dll" };
+        var sut = CreateSut();
+
+        var result = await sut.RemoveAllReShadeFiles(game);
+
+        Assert.Same(game, result);
+        Assert.True(File.Exists(dllPath));
+        Assert.True(File.Exists(asiPath));
+        Assert.Null(game.ReShade);
+    }
+
+    [Fact]
+    public async Task RemoveAllRenoDXFiles_WhenDirectoryIsEmpty_ClearsGameState()
+    {
+        using var temp = new TempDirectory();
+        var game = CreateGame(temp.CreateDirectory("game"));
+        game.RenoDX = new RenoDX { SelectedName = "renodx-game.addon64" };
+        var sut = CreateSut();
+
+        var result = await sut.RemoveAllRenoDXFiles(game);
+
+        Assert.Same(game, result);
+        Assert.Null(game.RenoDX);
+    }
+
+    [Fact]
+    public async Task RemoveAllRenoDXFiles_WhenFilesAreNotVerifiedRenoDX_LeavesFilesAndClearsGameState()
+    {
+        using var temp = new TempDirectory();
+        var gameDir = temp.CreateDirectory("game");
+        var addon64Path = temp.CreateFile(Path.Combine("game", "renodx-game.addon64"), "not-a-pe-file");
+        var addon32Path = temp.CreateFile(Path.Combine("game", "renodx-game.addon32"), "not-a-pe-file");
+        var game = CreateGame(gameDir);
+        game.RenoDX = new RenoDX { SelectedName = "renodx-game.addon64" };
+        var sut = CreateSut();
+
+        var result = await sut.RemoveAllRenoDXFiles(game);
+
+        Assert.Same(game, result);
+        Assert.True(File.Exists(addon64Path));
+        Assert.True(File.Exists(addon32Path));
+        Assert.Null(game.RenoDX);
+    }
+
+    private static Game CreateGame(string executablePath) =>
+        new()
+        {
+            Name = "Test Game",
+            ExecutablePath = executablePath
+        };
+
+    private static ModInstallService CreateSut() => new(new NoOpLogService());
+}

--- a/src/Restall.Tests/Infrastructure/ModInstallServiceTests.cs
+++ b/src/Restall.Tests/Infrastructure/ModInstallServiceTests.cs
@@ -6,6 +6,7 @@ namespace Restall.Tests.Infrastructure;
 
 public sealed class ModInstallServiceTests
 {
+    // Verifies that installing ReShade copies the source file and updates the game state.
     [Fact]
     public async Task InstallModAsync_WhenInstallingReShade_CopiesFileAndUpdatesGameState()
     {
@@ -28,6 +29,7 @@ public sealed class ModInstallServiceTests
         Assert.Equal("reshade-content", File.ReadAllText(Path.Combine(gameDir, "dxgi.dll")));
     }
 
+    // Verifies that replacing ReShade removes the old selected file and copies the new one.
     [Fact]
     public async Task InstallModAsync_WhenReplacingExistingReShade_RemovesOldFileAndCopiesNewFile()
     {
@@ -52,6 +54,7 @@ public sealed class ModInstallServiceTests
         Assert.Same(reShade, game.ReShade);
     }
 
+    // Verifies that a missing ReShade source file returns a failure without changing game state.
     [Fact]
     public async Task InstallModAsync_WhenReShadeSourceIsMissing_ReturnsFailure()
     {
@@ -69,6 +72,7 @@ public sealed class ModInstallServiceTests
         Assert.False(File.Exists(Path.Combine(gameDir, "dxgi.dll")));
     }
 
+    // Verifies that installing RenoDX copies the addon file and updates the game state.
     [Fact]
     public async Task InstallModAsync_WhenInstallingRenoDX_CopiesFileAndUpdatesGameState()
     {
@@ -92,6 +96,7 @@ public sealed class ModInstallServiceTests
         Assert.Equal("renodx-content", File.ReadAllText(Path.Combine(gameDir, "renodx-game.addon64")));
     }
 
+    // Verifies that RenoDX installs under the selected name when original and selected names differ.
     [Fact]
     public async Task InstallModAsync_WhenRenoDXOriginalNameDiffersFromSelectedName_CopiesSelectedFile()
     {
@@ -116,6 +121,7 @@ public sealed class ModInstallServiceTests
         Assert.Same(renoDX, game.RenoDX);
     }
 
+    // Verifies that a missing RenoDX source file returns a failure without changing game state.
     [Fact]
     public async Task InstallModAsync_WhenRenoDXSourceIsMissing_ReturnsFailure()
     {
@@ -137,6 +143,7 @@ public sealed class ModInstallServiceTests
         Assert.False(File.Exists(Path.Combine(gameDir, "renodx-game.addon64")));
     }
 
+    // Verifies that ReShade uninstall deletes the selected file and clears the game state.
     [Fact]
     public async Task UninstallReShadeAsync_WhenFileExists_RemovesFileAndClearsGameState()
     {
@@ -154,6 +161,7 @@ public sealed class ModInstallServiceTests
         Assert.Null(game.ReShade);
     }
 
+    // Verifies that missing ReShade uninstall targets return a deep-scan failure.
     [Fact]
     public async Task UninstallReShadeAsync_WhenFileIsMissing_ReturnsFailureAndPromptsForDeepScan()
     {
@@ -169,6 +177,7 @@ public sealed class ModInstallServiceTests
         Assert.Null(game.ReShade);
     }
 
+    // Verifies that missing RenoDX uninstall targets return a deep-scan failure.
     [Fact]
     public async Task UninstallRenoDXAsync_WhenFileIsMissing_ReturnsFailureAndPromptsForDeepScan()
     {
@@ -184,6 +193,7 @@ public sealed class ModInstallServiceTests
         Assert.Null(game.RenoDX);
     }
 
+    // Verifies that unverified RenoDX files are not deleted during uninstall.
     [Fact]
     public async Task UninstallRenoDXAsync_WhenFileIsNotVerifiedRenoDX_DoesNotDeleteFileButClearsGameState()
     {
@@ -202,6 +212,7 @@ public sealed class ModInstallServiceTests
         Assert.Null(game.RenoDX);
     }
 
+    // Verifies that removing all ReShade files in an empty folder still clears game state.
     [Fact]
     public async Task RemoveAllReShadeFiles_WhenDirectoryIsEmpty_ClearsGameState()
     {
@@ -216,6 +227,7 @@ public sealed class ModInstallServiceTests
         Assert.Null(game.ReShade);
     }
 
+    // Verifies that non-ReShade placeholder files are ignored during bulk ReShade removal.
     [Fact]
     public async Task RemoveAllReShadeFiles_WhenFilesAreNotVerifiedReShade_LeavesFilesAndClearsGameState()
     {
@@ -235,6 +247,7 @@ public sealed class ModInstallServiceTests
         Assert.Null(game.ReShade);
     }
 
+    // Verifies that removing all RenoDX files in an empty folder still clears game state.
     [Fact]
     public async Task RemoveAllRenoDXFiles_WhenDirectoryIsEmpty_ClearsGameState()
     {
@@ -249,6 +262,7 @@ public sealed class ModInstallServiceTests
         Assert.Null(game.RenoDX);
     }
 
+    // Verifies that non-RenoDX placeholder files are ignored during bulk RenoDX removal.
     [Fact]
     public async Task RemoveAllRenoDXFiles_WhenFilesAreNotVerifiedRenoDX_LeavesFilesAndClearsGameState()
     {

--- a/src/Restall.Tests/Infrastructure/ParseServiceTests.cs
+++ b/src/Restall.Tests/Infrastructure/ParseServiceTests.cs
@@ -1,0 +1,190 @@
+using System.Net;
+using Restall.Application.DTOs;
+using Restall.Domain.Entities;
+using Restall.Infrastructure.Services;
+using Restall.Tests.TestUtilities;
+
+namespace Restall.Tests.Infrastructure;
+
+public sealed class ParseServiceTests
+{
+    // Verifies that ReShade versions are parsed, deduplicated and prefixed by a newer site version.
+    [Fact]
+    public async Task FetchReShadeVersionsAsync_ParsesTagsAndPrefixesNewerSiteVersion()
+    {
+        var sut = CreateService(new Dictionary<string, string>
+        {
+            ["https://github.com/crosire/reshade/tags"] = """
+                <html><body>
+                  <a href="/crosire/reshade/releases/tag/v6.4.0">v6.4.0</a>
+                  <a href="/crosire/reshade/releases/tag/v6.4.0">duplicate</a>
+                  <a href="/crosire/reshade/releases/tag/v6.3.0">v6.3.0</a>
+                </body></html>
+                """,
+            ["https://reshade.me"] = "<html><body>Download ReShade 6.5.0 today</body></html>"
+        });
+
+        var result = await sut.FetchReShadeVersionsAsync();
+
+        Assert.Equal(["6.5.0", "6.4.0", "6.3.0"], result);
+    }
+
+    // Verifies that ReShade HTTP failures are swallowed and return an empty list.
+    [Fact]
+    public async Task FetchReShadeVersionsAsync_WhenHttpFails_ReturnsEmptyList()
+    {
+        var handler = new FakeHttpMessageHandler(_ => FakeHttpMessageHandler.TextResponse("fail", HttpStatusCode.InternalServerError));
+        var sut = CreateService(handler);
+
+        var result = await sut.FetchReShadeVersionsAsync();
+
+        Assert.Empty(result);
+    }
+
+    // Verifies that snapshot releases parse date and commit notes from release HTML.
+    [Fact]
+    public async Task FetchRenoDXSnapshotAsync_ParsesReleaseDateAndCommitNotes()
+    {
+        var sut = CreateService(new Dictionary<string, string>
+        {
+            ["https://github.com/clshortfuse/renodx/releases/tag/snapshot"] = """
+                <html><body>
+                  <relative-time datetime="2024-02-03T12:00:00Z"></relative-time>
+                  <div class="markdown-body">
+                    <h2>Added</h2>
+                    <ul><li>First change</li></ul>
+                    <h2>Fixed</h2>
+                    <ul><li>Second change</li></ul>
+                  </div>
+                </body></html>
+                """
+        });
+
+        var result = await sut.FetchRenoDXSnapshotAsync();
+
+        Assert.NotNull(result);
+        Assert.Equal(new DateOnly(2024, 2, 3), result.Date);
+        Assert.Equal(RenoDX.Branch.Snapshot, result.Branch);
+        Assert.Equal(["[Added] First change", "[Fixed] Second change"], result.CommitNotes);
+    }
+
+    // Verifies that snapshot releases without a parseable date return null.
+    [Fact]
+    public async Task FetchRenoDXSnapshotAsync_WhenDateIsMissing_ReturnsNull()
+    {
+        var sut = CreateService(new Dictionary<string, string>
+        {
+            ["https://github.com/clshortfuse/renodx/releases/tag/snapshot"] = "<html><body><div class=\"markdown-body\"></div></body></html>"
+        });
+
+        var result = await sut.FetchRenoDXSnapshotAsync();
+
+        Assert.Null(result);
+    }
+
+    // Verifies that nightly tags and release notes are parsed while invalid nightly tags are ignored.
+    [Fact]
+    public async Task FetchRenoDXNightlyTagsAsync_ParsesNightlyTagsAndIgnoresInvalidDates()
+    {
+        var sut = CreateService(new Dictionary<string, string>
+        {
+            ["https://github.com/clshortfuse/renodx/tags"] = """
+                <html><body>
+                  <a href="/clshortfuse/renodx/releases/tag/nightly-20240203">nightly-20240203</a>
+                  <a href="/clshortfuse/renodx/releases/tag/nightly-invalid">nightly-invalid</a>
+                  <a href="/clshortfuse/renodx/releases/tag/nightly-20240202">nightly-20240202</a>
+                  <a href="/clshortfuse/renodx/releases/tag/nightly-20240202">duplicate</a>
+                </body></html>
+                """,
+            ["https://github.com/clshortfuse/renodx/releases/tag/nightly-20240203"] = """
+                <html><body>
+                  <pre class="text-small ws-pre-wrap">Header
+                  First nightly note
+                  Second nightly note</pre>
+                </body></html>
+                """,
+            ["https://github.com/clshortfuse/renodx/releases/tag/nightly-20240202"] = "<html><body></body></html>"
+        });
+
+        var result = await sut.FetchRenoDXNightlyTagsAsync();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("20240203", result[0].Version);
+        Assert.Equal(["First nightly note", "Second nightly note"], result[0].CommitNotes);
+        Assert.Equal("20240202", result[1].Version);
+        Assert.Null(result[1].CommitNotes);
+    }
+
+    // Verifies that RenoDX wiki markdown parses specific and generic mod tables.
+    [Fact]
+    public async Task FetchRenoDXWikiModsAsync_ParsesSpecificAndGenericModTables()
+    {
+        var sut = CreateService(new Dictionary<string, string>
+        {
+            ["https://raw.githubusercontent.com/wiki/clshortfuse/renodx/Mods.md"] = """
+                | Game | Maintainer | Links | Status |
+                | --- | --- | --- | --- |
+                | [Specific Game](https://example.test/game) | Alice | [x64](https://example.test/renodx-specific.addon64) [x32](https://example.test/renodx-specific.addon32) [Nexus](https://www.nexusmods.com/game) [Discord](https://discord.gg/game) | ok |
+
+                ### Unreal Engine
+                | Game | Status | Notes |
+                | --- | --- | --- |
+                | [Generic Unreal](https://example.test/unreal) | ok | Use for Unreal |
+
+                ### Unity Engine
+                | Game | Status | Notes |
+                | --- | --- | --- |
+                | Generic Unity | warning | |
+                """
+        });
+
+        var result = await sut.FetchRenoDXWikiModsAsync();
+
+        var wikiMod = Assert.Single(result.WikiMods);
+        Assert.Equal("Specific Game", wikiMod.Name);
+        Assert.Equal("Alice", wikiMod.Maintainer);
+        Assert.Equal("https://example.test/renodx-specific.addon64", wikiMod.SnapshotUrl64);
+        Assert.Equal("https://example.test/renodx-specific.addon32", wikiMod.SnapshotUrl32);
+        Assert.Equal("https://www.nexusmods.com/game", wikiMod.NexusUrl);
+        Assert.Equal("https://discord.gg/game", wikiMod.DiscordUrl);
+
+        Assert.Equal(2, result.GenericWikiMods.Count);
+        Assert.Equal(SupportedEngine.Unreal, result.GenericWikiMods[0].Engine);
+        Assert.Equal("Use for Unreal", result.GenericWikiMods[0].Notes);
+        Assert.Equal(SupportedEngine.Unity, result.GenericWikiMods[1].Engine);
+        Assert.Null(result.GenericWikiMods[1].Notes);
+    }
+
+    // Verifies that RenoDX wiki HTTP failures return empty mod lists.
+    [Fact]
+    public async Task FetchRenoDXWikiModsAsync_WhenHttpFails_ReturnsEmptyLists()
+    {
+        var handler = new FakeHttpMessageHandler(_ => FakeHttpMessageHandler.TextResponse("fail", HttpStatusCode.InternalServerError));
+        var sut = CreateService(handler);
+
+        var result = await sut.FetchRenoDXWikiModsAsync();
+
+        Assert.Empty(result.WikiMods);
+        Assert.Empty(result.GenericWikiMods);
+    }
+
+    private static ParseService CreateService(IReadOnlyDictionary<string, string> responses)
+    {
+        var handler = new FakeHttpMessageHandler(request =>
+        {
+            var uri = request.RequestUri!.ToString();
+            var fallbackUri = uri.EndsWith("/", StringComparison.Ordinal) ? uri.TrimEnd('/') : uri;
+            return (responses.TryGetValue(uri, out var content) || responses.TryGetValue(fallbackUri, out content))
+                ? FakeHttpMessageHandler.TextResponse(content)
+                : FakeHttpMessageHandler.TextResponse($"No fake response for {uri}", HttpStatusCode.NotFound);
+        });
+
+        return CreateService(handler);
+    }
+
+    private static ParseService CreateService(FakeHttpMessageHandler handler)
+    {
+        var client = new HttpClient(handler);
+        return new ParseService(new NoOpLogService(), new FakeHttpClientFactory(client));
+    }
+}

--- a/src/Restall.Tests/Infrastructure/PathServiceTests.cs
+++ b/src/Restall.Tests/Infrastructure/PathServiceTests.cs
@@ -1,0 +1,61 @@
+using Restall.Domain.Entities;
+using Restall.Infrastructure.Services;
+
+namespace Restall.Tests.Infrastructure;
+
+public sealed class PathServiceTests
+{
+    // Verifies that SteamGridDB cache paths use the expected cache directory and artwork filenames.
+    [Fact]
+    public void SgdbPaths_ReturnExpectedCachePaths()
+    {
+        var sut = new PathService();
+
+        Assert.EndsWith(Path.Combine("Restall", "Cache", "SGDB"), sut.GetSgdbCacheDirectory());
+        Assert.EndsWith(Path.Combine("Restall", "Cache", "SGDB", "42", "banner.png"), sut.GetSgdbBannerPath(42));
+        Assert.EndsWith(Path.Combine("Restall", "Cache", "SGDB", "42", "icon.png"), sut.GetSgdbThumbnailPath(42));
+        Assert.EndsWith(Path.Combine("Restall", "Cache", "SGDB", "42", "logo.png"), sut.GetSgdbLogoPath(42));
+    }
+
+    // Verifies that ReShade cache and installer paths include branch, version and original filename.
+    [Fact]
+    public void ReShadePaths_ReturnExpectedCacheAndDownloadPaths()
+    {
+        var sut = new PathService();
+        var reShade = new ReShade
+        {
+            BranchName = ReShade.Branch.Stable,
+            Version = "6.5.0",
+            Arch = ReShade.Architecture.x32
+        };
+
+        Assert.EndsWith(Path.Combine("Restall", "Cache", "ReShade", "Stable", "6.5.0"), sut.GetReShadeCachePath(reShade));
+        Assert.EndsWith(Path.Combine("Restall", "DownloadCache", "ReShade", "Stable"), sut.GetReShadeDownloadCachePath(ReShade.Branch.Stable));
+        Assert.EndsWith(Path.Combine("Restall", "DownloadCache", "ReShade", "Stable", "ReShade_Setup_6.5.0_Addon.exe"), sut.GetReShadeInstallerFilePath(ReShade.Branch.Stable, "6.5.0"));
+        Assert.EndsWith(Path.Combine("Restall", "Cache", "ReShade", "Stable", "6.5.0", "ReShade32.dll"), sut.GetReShadeExtractedFilePath(reShade));
+    }
+
+    // Verifies that RenoDX cache and download paths include branch and original addon name.
+    [Fact]
+    public void RenoDXPaths_ReturnExpectedCacheAndDownloadPaths()
+    {
+        var sut = new PathService();
+        var renoDx = new RenoDX
+        {
+            BranchName = RenoDX.Branch.Nightly,
+            OriginalName = "renodx-unrealengine.addon64"
+        };
+
+        Assert.EndsWith(Path.Combine("Restall", "DownloadCache", "RenoDX", "Nightly", "renodx-unrealengine.addon64"), sut.GetRenoDXCachePath(renoDx));
+        Assert.EndsWith(Path.Combine("Restall", "DownloadCache", "RenoDX", "Snapshot"), sut.GetRenoDXDownloadCachePath(RenoDX.Branch.Snapshot));
+    }
+
+    // Verifies that the default log directory is under the Restall local app data folder.
+    [Fact]
+    public void GetDefaultLogPath_ReturnsRestallLogsDirectory()
+    {
+        var sut = new PathService();
+
+        Assert.EndsWith(Path.Combine("Restall", "Logs"), sut.GetDefaultLogPath());
+    }
+}

--- a/src/Restall.Tests/Infrastructure/RegexHelperTests.cs
+++ b/src/Restall.Tests/Infrastructure/RegexHelperTests.cs
@@ -1,0 +1,68 @@
+using Restall.Infrastructure.Helpers;
+
+namespace Restall.Tests.Infrastructure;
+
+public sealed class RegexHelperTests
+{
+    // Verifies that RenoDX file-version strings expose the expected date parts.
+    [Fact]
+    public void RenoDXVersionRegex_WhenVersionHasExpectedShape_CapturesYearAndDay()
+    {
+        var match = RegexHelper.RenoDXVersionRegex.Match("1.2024.0203.0");
+
+        Assert.True(match.Success);
+        Assert.Equal("2024", match.Groups[1].Value);
+        Assert.Equal("0203", match.Groups[2].Value);
+    }
+
+    // Verifies that invalid RenoDX file-version strings do not match.
+    [Fact]
+    public void RenoDXVersionRegex_WhenVersionHasUnexpectedShape_DoesNotMatch()
+    {
+        var match = RegexHelper.RenoDXVersionRegex.Match("2024.02.03");
+
+        Assert.False(match.Success);
+    }
+
+    // Verifies that the ReShade site regex extracts the semantic version from page text.
+    [Fact]
+    public void ExtractReShadeVersionFromSite_WhenTextContainsVersion_CapturesVersion()
+    {
+        var match = RegexHelper.ExtractReShadeVersionFromSite.Match("Download ReShade 6.5.0 with full add-on support");
+
+        Assert.True(match.Success);
+        Assert.Equal("6.5.0", match.Groups[1].Value);
+    }
+
+    // Verifies that Steam library regex captures VDF library paths.
+    [Fact]
+    public void SteamLibraryRegex_WhenPathEntryExists_CapturesPath()
+    {
+        const string vdf = "\"libraryfolders\"\n{\n  \"1\"\n  {\n    \"path\" \"D:\\\\SteamLibrary\"\n  }\n}";
+
+        var match = RegexHelper.SteamLibraryRegex.Match(vdf);
+
+        Assert.True(match.Success);
+        Assert.Equal("D:\\\\SteamLibrary", match.Groups[1].Value);
+    }
+
+    // Verifies that Heroic regexes extract game block details from installed.json content.
+    [Fact]
+    public void HeroicRegexes_WhenBlockContainsGameDetails_CaptureExpectedValues()
+    {
+        const string json = """
+        {
+          "alpha": { "appName": "alpha-app", "title": "Alpha Game", "install_path": "C:\\Games\\Alpha" },
+          "ignored": { "title": "No install path" }
+        }
+        """;
+
+        var blockMatch = RegexHelper.HeroicGameBlockRegex.Match(json);
+        Assert.True(blockMatch.Success);
+
+        var block = blockMatch.Value;
+        Assert.Equal("alpha-app", RegexHelper.HeroicAppNameRegex.Match(block).Groups[1].Value);
+        Assert.Equal("Alpha Game", RegexHelper.HeroicTitleRegex.Match(block).Groups[1].Value);
+        Assert.Equal("C:\\\\Games\\\\Alpha", RegexHelper.HeroicInstallPathRegex.Match(block).Groups[1].Value);
+    }
+}

--- a/src/Restall.Tests/Infrastructure/SteamGridDbIndexRepositoryTests.cs
+++ b/src/Restall.Tests/Infrastructure/SteamGridDbIndexRepositoryTests.cs
@@ -1,0 +1,85 @@
+using Moq;
+using Restall.Application.Interfaces.Driven;
+using Restall.Infrastructure.Persistence;
+using Restall.Tests.TestUtilities;
+
+namespace Restall.Tests.Infrastructure;
+
+public sealed class SteamGridDbIndexRepositoryTests
+{
+    // Verifies that missing index files produce an empty index.
+    [Fact]
+    public void TryGetSteamGridDbId_WhenIndexFileIsMissing_ReturnsNull()
+    {
+        using var temp = new TempDirectory();
+        var sut = CreateRepository(temp);
+
+        var result = sut.TryGetSteamGridDbId("steam:1");
+
+        Assert.Null(result);
+        Assert.True(Directory.Exists(temp.GetPath("sgdb")));
+    }
+
+    // Verifies that saved ids can be read back from the same repository instance.
+    [Fact]
+    public async Task SaveSteamGridDbIdAsync_SavesIdInMemory()
+    {
+        using var temp = new TempDirectory();
+        var sut = CreateRepository(temp);
+
+        await sut.SaveSteamGridDbIdAsync("steam:1", 123);
+
+        Assert.Equal(123, sut.TryGetSteamGridDbId("steam:1"));
+    }
+
+    // Verifies that saved ids are persisted to index.json and loaded by a new repository instance.
+    [Fact]
+    public async Task SaveSteamGridDbIdAsync_PersistsIdToDisk()
+    {
+        using var temp = new TempDirectory();
+        var first = CreateRepository(temp);
+
+        await first.SaveSteamGridDbIdAsync("steam:1", 123);
+        var second = CreateRepository(temp);
+
+        Assert.Equal(123, second.TryGetSteamGridDbId("steam:1"));
+        Assert.Contains("\"steam:1\"", File.ReadAllText(temp.GetPath("sgdb", "index.json")));
+    }
+
+    // Verifies that saving an existing cache key overwrites the previous id.
+    [Fact]
+    public async Task SaveSteamGridDbIdAsync_WhenKeyAlreadyExists_OverwritesId()
+    {
+        using var temp = new TempDirectory();
+        var sut = CreateRepository(temp);
+
+        await sut.SaveSteamGridDbIdAsync("steam:1", 123);
+        await sut.SaveSteamGridDbIdAsync("steam:1", 456);
+
+        Assert.Equal(456, sut.TryGetSteamGridDbId("steam:1"));
+    }
+
+    // Verifies that corrupt index files are ignored without throwing.
+    [Fact]
+    public void Constructor_WhenIndexFileIsCorrupt_LoadsEmptyIndexAndLogsError()
+    {
+        using var temp = new TempDirectory();
+        temp.CreateFile(Path.Combine("sgdb", "index.json"), "{ invalid json");
+        var log = new Mock<ILogService>(MockBehavior.Loose);
+
+        var sut = CreateRepository(temp, log.Object);
+
+        Assert.Null(sut.TryGetSteamGridDbId("steam:1"));
+        log.Verify(x => x.LogError(
+            It.Is<string>(message => message.Contains("Failed to load index file")),
+            It.IsAny<Exception?>(),
+            It.IsAny<string>()), Times.Once);
+    }
+
+    private static SteamGridDbIndexRepository CreateRepository(TempDirectory temp, ILogService? logService = null)
+    {
+        var pathService = new Mock<IPathService>(MockBehavior.Strict);
+        pathService.Setup(x => x.GetSgdbCacheDirectory()).Returns(temp.GetPath("sgdb"));
+        return new SteamGridDbIndexRepository(logService ?? new NoOpLogService(), pathService.Object);
+    }
+}

--- a/src/Restall.Tests/Infrastructure/VersionCatalogTests.cs
+++ b/src/Restall.Tests/Infrastructure/VersionCatalogTests.cs
@@ -1,0 +1,88 @@
+using Moq;
+using Restall.Application.DTOs;
+using Restall.Application.Interfaces.Driven;
+using Restall.Domain.Entities;
+using Restall.Infrastructure.Stores;
+using Restall.Tests.TestUtilities;
+
+namespace Restall.Tests.Infrastructure;
+
+public sealed class VersionCatalogTests
+{
+    // Verifies that version fetch populates ReShade and RenoDX catalogs from the parse service.
+    [Fact]
+    public async Task FetchVersionsAsync_PopulatesAvailableVersionsAndLatestTags()
+    {
+        var parse = new Mock<IParseService>(MockBehavior.Strict);
+        var snapshot = new RenoDXTagInfoDto(new DateOnly(2024, 2, 2), RenoDX.Branch.Snapshot);
+        var nightly = new RenoDXTagInfoDto(new DateOnly(2024, 2, 1), RenoDX.Branch.Nightly);
+        parse.Setup(x => x.FetchReShadeVersionsAsync()).ReturnsAsync(new[] { "6.5.0", "6.4.0" });
+        parse.Setup(x => x.FetchRenoDXSnapshotAsync()).ReturnsAsync(snapshot);
+        parse.Setup(x => x.FetchRenoDXNightlyTagsAsync()).ReturnsAsync(new[] { nightly });
+        var sut = new VersionCatalog(parse.Object, new NoOpLogService());
+
+        await sut.FetchVersionsAsync();
+
+        Assert.Equal("6.5.0", sut.GetLatestReShadeVersion(ReShade.Branch.Stable));
+        Assert.Equal(new[] { "6.5.0", "6.4.0" }, sut.GetAvailableReShadeVersions(ReShade.Branch.Stable));
+        Assert.Same(snapshot, sut.GetLatestRenoDXVersionByTag(RenoDX.Branch.Snapshot));
+        Assert.Same(nightly, sut.GetLatestRenoDXVersionByTag(RenoDX.Branch.Nightly));
+        Assert.Equal(new[] { nightly }, sut.GetAllRenoDXNightlies());
+    }
+
+    // Verifies that fetching versions clears stale catalog data before repopulating.
+    [Fact]
+    public async Task FetchVersionsAsync_WhenCalledAgain_ClearsStaleValues()
+    {
+        var parse = new Mock<IParseService>(MockBehavior.Strict);
+        var firstSnapshot = new RenoDXTagInfoDto(new DateOnly(2024, 2, 2), RenoDX.Branch.Snapshot);
+
+        parse.SetupSequence(x => x.FetchReShadeVersionsAsync())
+            .ReturnsAsync(new[] { "6.5.0" })
+            .ReturnsAsync(Array.Empty<string>());
+        parse.SetupSequence(x => x.FetchRenoDXSnapshotAsync())
+            .ReturnsAsync(firstSnapshot)
+            .ReturnsAsync((RenoDXTagInfoDto?)null);
+        parse.SetupSequence(x => x.FetchRenoDXNightlyTagsAsync())
+            .ReturnsAsync(new[] { new RenoDXTagInfoDto(new DateOnly(2024, 2, 1), RenoDX.Branch.Nightly) })
+            .ReturnsAsync(Array.Empty<RenoDXTagInfoDto>());
+        var sut = new VersionCatalog(parse.Object, new NoOpLogService());
+
+        await sut.FetchVersionsAsync();
+        await sut.FetchVersionsAsync();
+
+        Assert.Null(sut.GetLatestReShadeVersion(ReShade.Branch.Stable));
+        Assert.Empty(sut.GetAvailableReShadeVersions(ReShade.Branch.Stable));
+        Assert.Null(sut.GetLatestRenoDXVersionByTag(RenoDX.Branch.Snapshot));
+        Assert.Null(sut.GetLatestRenoDXVersionByTag(RenoDX.Branch.Nightly));
+        Assert.Empty(sut.GetAllRenoDXNightlies());
+    }
+
+    // Verifies that unknown catalog branches return empty values before any fetch.
+    [Fact]
+    public void Getters_WhenCatalogIsEmpty_ReturnEmptyValues()
+    {
+        var parse = new Mock<IParseService>(MockBehavior.Strict);
+        var sut = new VersionCatalog(parse.Object, new NoOpLogService());
+
+        Assert.Null(sut.GetLatestReShadeVersion(ReShade.Branch.Stable));
+        Assert.Empty(sut.GetAvailableReShadeVersions(ReShade.Branch.Stable));
+        Assert.Null(sut.GetLatestRenoDXVersionByTag(RenoDX.Branch.Snapshot));
+        Assert.Empty(sut.GetAllRenoDXNightlies());
+    }
+
+    // Verifies that missing snapshot data does not create a Snapshot catalog entry.
+    [Fact]
+    public async Task FetchVersionsAsync_WhenSnapshotIsMissing_LeavesSnapshotLatestNull()
+    {
+        var parse = new Mock<IParseService>(MockBehavior.Strict);
+        parse.Setup(x => x.FetchReShadeVersionsAsync()).ReturnsAsync(new[] { "6.5.0" });
+        parse.Setup(x => x.FetchRenoDXSnapshotAsync()).ReturnsAsync((RenoDXTagInfoDto?)null);
+        parse.Setup(x => x.FetchRenoDXNightlyTagsAsync()).ReturnsAsync(Array.Empty<RenoDXTagInfoDto>());
+        var sut = new VersionCatalog(parse.Object, new NoOpLogService());
+
+        await sut.FetchVersionsAsync();
+
+        Assert.Null(sut.GetLatestRenoDXVersionByTag(RenoDX.Branch.Snapshot));
+    }
+}

--- a/src/Restall.Tests/Restall.Tests.csproj
+++ b/src/Restall.Tests/Restall.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Restall.Application\Restall.Application.csproj" />
+    <ProjectReference Include="..\Restall.Domain\Restall.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Restall.Tests/Restall.Tests.csproj
+++ b/src/Restall.Tests/Restall.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>
@@ -21,6 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Restall.Application\Restall.Application.csproj" />
     <ProjectReference Include="..\Restall.Domain\Restall.Domain.csproj" />
+    <ProjectReference Include="..\Restall.Infrastructure\Restall.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Restall.Tests/TestUtilities/FakeHttpClientFactory.cs
+++ b/src/Restall.Tests/TestUtilities/FakeHttpClientFactory.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Text;
+
+namespace Restall.Tests.TestUtilities;
+
+internal sealed class FakeHttpClientFactory : IHttpClientFactory
+{
+    private readonly HttpClient _client;
+
+    public FakeHttpClientFactory(HttpClient client)
+    {
+        _client = client;
+    }
+
+    public HttpClient CreateClient(string name) => _client;
+}
+
+internal sealed class FakeHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+    private readonly List<Uri?> _requestUris = [];
+    private readonly object _lock = new();
+
+    public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+    {
+        _handler = handler;
+    }
+
+    public IReadOnlyList<Uri?> RequestUris
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _requestUris.ToArray();
+            }
+        }
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        lock (_lock)
+        {
+            _requestUris.Add(request.RequestUri);
+        }
+
+        return Task.FromResult(_handler(request));
+    }
+
+    public static HttpResponseMessage TextResponse(string content, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        return new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(content, Encoding.UTF8)
+        };
+    }
+
+    public static HttpResponseMessage BytesResponse(byte[] content, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        return new HttpResponseMessage(statusCode)
+        {
+            Content = new ByteArrayContent(content)
+        };
+    }
+}

--- a/src/Restall.Tests/TestUtilities/NoOpLogService.cs
+++ b/src/Restall.Tests/TestUtilities/NoOpLogService.cs
@@ -1,0 +1,25 @@
+using Restall.Application.Interfaces.Driven;
+
+namespace Restall.Tests.TestUtilities;
+
+internal sealed class NoOpLogService : ILogService
+{
+    public void LogInfo(string message, string logFileName = "restall_log.txt")
+    {
+    }
+
+    public void LogWarning(string message, string logFileName = "restall_log.txt")
+    {
+    }
+
+    public void LogError(string message, Exception? exception = null, string logFileName = "restall_log.txt")
+    {
+    }
+
+    public Task LogInfoAsync(string message, string logFileName = "restall_log.txt") => Task.CompletedTask;
+
+    public Task LogWarningAsync(string message, string logFileName = "restall_log.txt") => Task.CompletedTask;
+
+    public Task LogErrorAsync(string message, Exception? exception = null, string logFileName = "restall_log.txt") =>
+        Task.CompletedTask;
+}

--- a/src/Restall.Tests/TestUtilities/TempDirectory.cs
+++ b/src/Restall.Tests/TestUtilities/TempDirectory.cs
@@ -1,0 +1,48 @@
+namespace Restall.Tests.TestUtilities;
+
+internal sealed class TempDirectory : IDisposable
+{
+    public TempDirectory()
+    {
+        DirectoryPath = Path.Combine(Path.GetTempPath(), "Restall.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(DirectoryPath);
+    }
+
+    public string DirectoryPath { get; }
+
+    public string GetPath(params string[] paths)
+    {
+        var combined = new string[paths.Length + 1];
+        combined[0] = DirectoryPath;
+        Array.Copy(paths, 0, combined, 1, paths.Length);
+        return Path.Combine(combined);
+    }
+
+    public string CreateDirectory(string relativePath)
+    {
+        var path = GetPath(relativePath);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    public string CreateFile(string relativePath, string contents = "")
+    {
+        var path = GetPath(relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, contents);
+        return path;
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(DirectoryPath))
+                Directory.Delete(DirectoryPath, recursive: true);
+        }
+        catch
+        {
+            // Best-effort cleanup for temp files that may be briefly locked by the runtime.
+        }
+    }
+}

--- a/src/Restall.Tests/packages.lock.json
+++ b/src/Restall.Tests/packages.lock.json
@@ -1,0 +1,113 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.14.1, )",
+        "resolved": "17.14.1",
+        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.14.1",
+          "Microsoft.TestPlatform.TestHost": "17.14.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.4, )",
+        "resolved": "3.1.4",
+        "contentHash": "5mj99LvCqrq3CNi06xYdyIAXOEh+5b33F2nErCzI5zWiDdLHXiPXEWFSUAF8zlIv0ZWqjZNCwHTQeAPYbF3pCg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "xTP1W6Mi6SWmuxd3a+jj9G9UoC850WGwZUps1Wah9r1ZxgXhdJfj1QqDLJkFjHDCvN42qDL2Ps5KjQYWUU0zcQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "d78LPzGKkJwsJXAQwsbJJ7LE7D1wB+rAyhHHAaODF+RDSQ0NgMjDFkSA1Djw18VrxO76GlKAjRUhl+H8NL8Z+Q==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "restall.application": {
+        "type": "Project",
+        "dependencies": {
+          "Restall.Domain": "[1.0.0, )"
+        }
+      },
+      "restall.domain": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/Restall.Tests/packages.lock.json
+++ b/src/Restall.Tests/packages.lock.json
@@ -18,6 +18,15 @@
           "Microsoft.TestPlatform.TestHost": "17.14.1"
         }
       },
+      "Moq": {
+        "type": "Direct",
+        "requested": "[4.20.72, )",
+        "resolved": "4.20.72",
+        "contentHash": "EA55cjyNn8eTNWrgrdZJH5QLFp2L43oxl1tlkoYUKIE9pRwL784OWiTXeCV5ApS+AMYEAlt7Fo03A2XfouvHmQ==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.9.3, )",
@@ -35,10 +44,146 @@
         "resolved": "3.1.4",
         "contentHash": "5mj99LvCqrq3CNi06xYdyIAXOEh+5b33F2nErCzI5zWiDdLHXiPXEWFSUAF8zlIv0ZWqjZNCwHTQeAPYbF3pCg=="
       },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "craftersmine.SteamGridDB.Net": {
+        "type": "Transitive",
+        "resolved": "1.1.7",
+        "contentHash": "RpxgWjFG+syzl2pvSrt9VZGrPejxVYdWh5ylLOnW+nd6ygDNG3hrKiIGZHGInnkgQ9gxyRGsahC9/tRXbnhxBw==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "HtmlAgilityPack": {
+        "type": "Transitive",
+        "resolved": "1.12.4",
+        "contentHash": "ljqvBabvFwKoLniuoQKO8b5bJfJweKLs4fUNS/V5dsvpo0A8MlJqxxn9XVmP2DaskbUXty6IYaWAi1SArGIMeQ=="
+      },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
         "resolved": "17.14.1",
         "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "vAJHd4yOpmKoK+jBuYV7a3y+Ab9U4ARCc29b6qvMy276RgJFw9LFs0DdsPqOL3ahwzyrX7tM+i4cCxU/RX0qAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "AiFvHYM8nP0wPC7bGPI3NHQlSYSLqjjT7DMJUuuxhd+7pz3O89iu2gdQfgACy5DxsXENiok5i1bMacJL7KR8jA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "+XTMKQyDWg4ODoNHU/BN3BaI1jhGO7VCS+BnzT/4IauiG6y2iPAte7MyD7rHKS+hNP0TkFkjrae8DFjDUxtcxg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
@@ -58,6 +203,30 @@
         "type": "Transitive",
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "PeNet": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lXCv2WWu0jdCWfEROA3+XBuD5V8ohENGLvw2ob/lP8g8ct0MdHIMWl44O8dLz61SSAP3oOtBqSYN5dYyk1RXCg==",
+        "dependencies": {
+          "PeNet.Asn1": "2.0.2",
+          "System.Security.Cryptography.Pkcs": "10.0.2"
+        }
+      },
+      "PeNet.Asn1": {
+        "type": "Transitive",
+        "resolved": "2.0.2",
+        "contentHash": "4CTnhPm8GqY/cb4tMvGG5VE3mNexoIuKuz5ZpX265QVfy7Vouio+oRwlEu2ZMGo0kmOuAm1JzLQvRI/LX+kfwQ=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "TVb4L6atqzRB33qBy4FVdmQMmDGzzBGwiwqI6u5WnJ6ag275pPLJgPWIVzYzT5hqTACrWyfHbttqylbexvur9w=="
       },
       "xunit.abstractions": {
         "type": "Transitive",
@@ -107,6 +276,18 @@
       },
       "restall.domain": {
         "type": "Project"
+      },
+      "restall.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "HtmlAgilityPack": "[1.12.4, )",
+          "Microsoft.Extensions.DependencyInjection": "[10.0.5, )",
+          "Microsoft.Extensions.Http": "[10.0.5, )",
+          "PeNet": "[6.0.0, )",
+          "Restall.Application": "[1.0.0, )",
+          "Restall.Domain": "[1.0.0, )",
+          "craftersmine.SteamGridDB.Net": "[1.1.7, )"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Adds xUnit + Moq test coverage for Domain, Application, and Infrastructure logic.
- Adds deterministic tests for update checks, install/uninstall flows, library refresh, catalogs, parsing, downloads, paths, logging, and helper logic.
- Adds GitHub Actions CI for pushes to all branches and pull requests.

## Verification
- `dotnet restore Restall.slnx --locked-mode`
- `dotnet build Restall.slnx --configuration Release --no-restore`
- `dotnet test Restall.slnx --configuration Release --no-build`

All tests pass locally: 206 tests.

## Notes
- Known NU1903 warning for `Tmds.DBus.Protocol` is left unchanged.
- Tests avoid network, registry, real launcher folders, and real game installs.