### PR TITLE
Fix wiki matching

### DIFF
--- a/src/Restall.Application/Helpers/GameCollectionCatalog.cs
+++ b/src/Restall.Application/Helpers/GameCollectionCatalog.cs
@@ -1,0 +1,38 @@
+using System.Collections.Immutable;
+using Restall.Domain.Entities;
+
+namespace Restall.Application.Helpers;
+
+public sealed record GameCollectionDefinition(
+    string Id,
+    ImmutableArray<string> NameKeywords,
+    ImmutableArray<string> PartSuffixes,
+    string ExecutablePathTemplate,
+    bool CollapseForModMatching = true
+)
+{
+    public bool Matches(string? name) =>
+        !string.IsNullOrWhiteSpace(name) &&
+        NameKeywords.All(k => name.Contains(k, StringComparison.OrdinalIgnoreCase));
+
+    public string BuildExecutablePath(Game game, string part) =>
+        Path.Combine(game.InstallFolder!, ExecutablePathTemplate
+            .Replace("{part}", part, StringComparison.OrdinalIgnoreCase)
+            .Replace('/', Path.DirectorySeparatorChar));
+}
+
+public static class GameCollectionCatalog
+{
+    public static readonly ImmutableArray<GameCollectionDefinition> All =
+    [
+        new GameCollectionDefinition(
+            "mass-effect-legendary",
+            ["Mass Effect", "Legendary Edition"],
+            ["ME1", "ME2", "ME3"],
+            "Game/{part}"
+        )
+    ];
+
+    public static GameCollectionDefinition? Find(string? name) =>
+        All.FirstOrDefault(d => d.Matches(name));
+}

--- a/src/Restall.Application/Helpers/GameCollectionCatalog.cs
+++ b/src/Restall.Application/Helpers/GameCollectionCatalog.cs
@@ -3,10 +3,12 @@ using Restall.Domain.Entities;
 
 namespace Restall.Application.Helpers;
 
+public sealed record GameCollectionPart(string DisplaySuffix, string FolderSegment);
+
 public sealed record GameCollectionDefinition(
     string Id,
     ImmutableArray<string> NameKeywords,
-    ImmutableArray<string> PartSuffixes,
+    ImmutableArray<GameCollectionPart> Parts,
     string ExecutablePathTemplate,
     bool CollapseForModMatching = true
 )
@@ -15,9 +17,9 @@ public sealed record GameCollectionDefinition(
         !string.IsNullOrWhiteSpace(name) &&
         NameKeywords.All(k => name.Contains(k, StringComparison.OrdinalIgnoreCase));
 
-    public string BuildExecutablePath(Game game, string part) =>
+    public string BuildExecutablePath(Game game, GameCollectionPart part) =>
         Path.Combine(game.InstallFolder!, ExecutablePathTemplate
-            .Replace("{part}", part, StringComparison.OrdinalIgnoreCase)
+            .Replace("{part}", part.FolderSegment, StringComparison.Ordinal)
             .Replace('/', Path.DirectorySeparatorChar));
 }
 
@@ -25,11 +27,24 @@ public static class GameCollectionCatalog
 {
     public static readonly ImmutableArray<GameCollectionDefinition> All =
     [
-        new GameCollectionDefinition(
+        new(
             "mass-effect-legendary",
             ["Mass Effect", "Legendary Edition"],
-            ["ME1", "ME2", "ME3"],
+            [
+                new("ME1", "ME1"),
+                new("ME2", "ME2"),
+                new("ME3", "ME3")
+            ],
             "Game/{part}"
+        ),
+        new(
+            "shenmue-1-2",
+            ["Shenmue I & II"],
+            [
+                new("I", "sm1"),
+                new("II", "sm2")
+            ],
+            "{part}"
         )
     ];
 

--- a/src/Restall.Application/Helpers/GameCollectionCatalog.cs
+++ b/src/Restall.Application/Helpers/GameCollectionCatalog.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using Restall.Domain.Entities;
 
 namespace Restall.Application.Helpers;
 
@@ -17,8 +16,8 @@ public sealed record GameCollectionDefinition(
         !string.IsNullOrWhiteSpace(name) &&
         NameKeywords.All(k => name.Contains(k, StringComparison.OrdinalIgnoreCase));
 
-    public string BuildExecutablePath(Game game, GameCollectionPart part) =>
-        Path.Combine(game.InstallFolder!, ExecutablePathTemplate
+    public string BuildExecutablePath(string installFolder, GameCollectionPart part) =>
+        Path.Combine(installFolder, ExecutablePathTemplate
             .Replace("{part}", part.FolderSegment, StringComparison.Ordinal)
             .Replace('/', Path.DirectorySeparatorChar));
 }

--- a/src/Restall.Application/Helpers/GameNameHelper.cs
+++ b/src/Restall.Application/Helpers/GameNameHelper.cs
@@ -105,14 +105,14 @@ public static partial class GameNameHelper
         var shared = aWords.Count(bSet.Contains);
         var maxWords = Math.Max(aWords.Length, bWords.Length);
 
-        if (maxWords > 0 && (double)shared / maxWords >= 0.5)
+        if (maxWords > 0 && (double)shared / maxWords > 0.5)
             return true;
 
         var (shorterDistinct, longerSet) = aWords.Length <= bWords.Length
             ? (aWords.Distinct().ToArray(), new HashSet<string>(bWords))
             : (bWords.Distinct().ToArray(), new HashSet<string>(aWords));
 
-        return shorterDistinct.Length >= 2 && shorterDistinct.All(w => longerSet.Contains(w));
+        return shorterDistinct.Length > 2 && shorterDistinct.All(w => longerSet.Contains(w));
     }
 
     public static bool IsLikelySameGame(string? a, string? b)

--- a/src/Restall.Application/Helpers/GameNameHelper.cs
+++ b/src/Restall.Application/Helpers/GameNameHelper.cs
@@ -25,9 +25,6 @@ public static partial class GameNameHelper
     [GeneratedRegex(@"^.*[-–]\s+(?<subtitle>\S.+)$")]
     private static partial Regex SubtitleSeparatorRegex();
 
-    [GeneratedRegex(@"[\u2018\u2019\u02BC\u0060\u00B4]")]
-    private static partial Regex ApostropheVariantRegex();
-
     [GeneratedRegex(
         @"^M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$",
         RegexOptions.IgnoreCase)]
@@ -36,15 +33,14 @@ public static partial class GameNameHelper
     [GeneratedRegex(@"\s*\(.*?\)\s*")]
     private static partial Regex ParentheticalRegex();
 
-    [GeneratedRegex(@"'s\b", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"[\u2018\u2019\u02BC\u0060\u00B4']s\b", RegexOptions.IgnoreCase)]
     private static partial Regex PossessiveRegex();
 
     public static string NormalizeName(string name)
     {
         if (string.IsNullOrWhiteSpace(name)) return string.Empty;
 
-        var canonicalized = ApostropheVariantRegex().Replace(name, "'");
-        var withoutEdition = StripEditionSuffix(canonicalized);
+        var withoutEdition = StripEditionSuffix(name);
         var withoutParentheticals = ParentheticalRegex().Replace(withoutEdition, " ").Trim();
         var withoutPossessiveness = PossessiveRegex().Replace(withoutParentheticals, string.Empty)
             .Trim();
@@ -142,14 +138,14 @@ public static partial class GameNameHelper
 
     private static string? ExtractDistinctEdition(string name) =>
         DistinctEditionSuffixRegex()
-                .Match(StripEditionSuffix(ApostropheVariantRegex().Replace(name, "'")))
+                .Match(StripEditionSuffix(name))
             is { Success: true } m
             ? m.Groups[2].Value.ToLowerInvariant()
             : null;
 
     private static bool HasUnrelatedTrailingSubtitle(string raw, string otherNormalized)
     {
-        var stripped = StripEditionSuffix(ApostropheVariantRegex().Replace(raw, "'"));
+        var stripped = StripEditionSuffix(raw);
 
         if (SubtitleSeparatorRegex().Match(stripped) is not { Success: true } match)
             return false;

--- a/src/Restall.Application/Helpers/GameNameHelper.cs
+++ b/src/Restall.Application/Helpers/GameNameHelper.cs
@@ -73,9 +73,9 @@ public static partial class GameNameHelper
         if (collection is null)
             return name;
 
-        foreach (var part in collection.PartSuffixes)
+        foreach (var part in collection.Parts)
         {
-            var pattern = $@"\s*[-–]\s*{Regex.Escape(part)}$";
+            var pattern = $@"\s*[-–]\s*{Regex.Escape(part.DisplaySuffix)}$";
 
             if (Regex.IsMatch(name, pattern, RegexOptions.IgnoreCase))
                 return Regex.Replace(name, pattern, string.Empty, RegexOptions.IgnoreCase).TrimEnd();

--- a/src/Restall.Application/Helpers/GameNameHelper.cs
+++ b/src/Restall.Application/Helpers/GameNameHelper.cs
@@ -9,33 +9,45 @@ public static partial class GameNameHelper
         ['i'] = 1, ['v'] = 5, ['x'] = 10, ['l'] = 50,
         ['c'] = 100, ['d'] = 500, ['m'] = 1000
     };
-    
+
     [GeneratedRegex(@"[^\w\s]")]
     private static partial Regex NonWordCharsRegex();
 
     [GeneratedRegex(
-        @"(\s*[-–:]\s*|\s+)(ultimate|complete|definitive|gold|deluxe|premium|anniversary|enhanced|enchanted|directors cut|remastered|remake|goty|game of the year|standard)(\s+edition)?\s*$",
+        @"(\s*[-–:]\s*|\s+)(ultimate|complete|gold|deluxe|premium|anniversary|directors cut|goty|game of the year|standard)(\s+edition)?\s*$",
         RegexOptions.IgnoreCase)]
     private static partial Regex EditionSuffixRegex();
+
+    [GeneratedRegex(@"(\s*[-–:]\s*|\s+)(remastered|remake|definitive|enhanced|enchanted)(\s+edition)?\s*$",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex DistinctEditionSuffixRegex();
+
+    [GeneratedRegex(@"^.*[-–]\s+(?<subtitle>\S.+)$")]
+    private static partial Regex SubtitleSeparatorRegex();
+
+    [GeneratedRegex(@"[\u2018\u2019\u02BC\u0060\u00B4]")]
+    private static partial Regex ApostropheVariantRegex();
 
     [GeneratedRegex(
         @"^M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$",
         RegexOptions.IgnoreCase)]
     private static partial Regex RomanNumeralRegex();
-    
+
     [GeneratedRegex(@"\s*\(.*?\)\s*")]
     private static partial Regex ParentheticalRegex();
-    
+
     [GeneratedRegex(@"'s\b", RegexOptions.IgnoreCase)]
     private static partial Regex PossessiveRegex();
 
     public static string NormalizeName(string name)
     {
         if (string.IsNullOrWhiteSpace(name)) return string.Empty;
-        
-        var withoutEdition = StripEditionSuffix(name);
+
+        var canonicalized = ApostropheVariantRegex().Replace(name, "'");
+        var withoutEdition = StripEditionSuffix(canonicalized);
         var withoutParentheticals = ParentheticalRegex().Replace(withoutEdition, " ").Trim();
-        var withoutPossessiveness = PossessiveRegex().Replace(withoutParentheticals, string.Empty).Trim();
+        var withoutPossessiveness = PossessiveRegex().Replace(withoutParentheticals, string.Empty)
+            .Trim();
 
         var cleanedName = NonWordCharsRegex().Replace(withoutPossessiveness, string.Empty)
             .Replace("  ", " ")
@@ -50,25 +62,47 @@ public static partial class GameNameHelper
                 string.Empty)
             .Trim();
 
+    public static string StripCollectionPartSuffix(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return name;
+
+        var collection = GameCollectionCatalog.All.FirstOrDefault(d =>
+            d.CollapseForModMatching && d.Matches(name));
+
+        if (collection is null)
+            return name;
+
+        foreach (var part in collection.PartSuffixes)
+        {
+            var pattern = $@"\s*[-–]\s*{Regex.Escape(part)}$";
+
+            if (Regex.IsMatch(name, pattern, RegexOptions.IgnoreCase))
+                return Regex.Replace(name, pattern, string.Empty, RegexOptions.IgnoreCase).TrimEnd();
+        }
+
+        return name;
+    }
+
     public static bool FuzzyNameMatch(string a, string b)
     {
         var aWords = a.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         var bWords = b.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         var aSet = new HashSet<string>(aWords);
         var bSet = new HashSet<string>(bWords);
-        
+
         var aHasNumeral = aWords.Any(w => w.All(char.IsDigit));
         var bHasNumeral = bWords.Any(w => w.All(char.IsDigit));
         if (aHasNumeral != bHasNumeral)
             return false;
 
-        var aContainsAllBWords = bWords.All(w => aSet.Contains(w));
-        var bContainsAllAWords = aWords.All(w => bSet.Contains(w));
+        var aContainsAllBWords = bWords.All(aSet.Contains);
+        var bContainsAllAWords = aWords.All(bSet.Contains);
 
         if (!aContainsAllBWords && !bContainsAllAWords)
             return false;
 
-        var shared = aWords.Count(w => bSet.Contains(w));
+        var shared = aWords.Count(bSet.Contains);
         var maxWords = Math.Max(aWords.Length, bWords.Length);
 
         if (maxWords > 0 && (double)shared / maxWords >= 0.5)
@@ -81,18 +115,54 @@ public static partial class GameNameHelper
         return shorterDistinct.Length >= 2 && shorterDistinct.All(w => longerSet.Contains(w));
     }
 
-    private static int ParseRoman(string roman)
+    public static bool IsLikelySameGame(string? a, string? b)
     {
-        var result = 0;
+        if (string.IsNullOrWhiteSpace(a) || string.IsNullOrWhiteSpace(b))
+            return false;
 
-        for (int i = 0; i < roman.Length; i++)
-        {
-            var current = RomanValues[roman[i]];
-            var next = i + 1 < roman.Length ? RomanValues[roman[i + 1]] : 0;
-            result += current < next ? -current : current;
-        }
+        var normA = NormalizeName(a);
+        var normB = NormalizeName(b);
 
-        return result;
+        if (normA == normB)
+            return true;
+
+        if (!FuzzyNameMatch(normA, normB))
+            return false;
+
+        var editionA = ExtractDistinctEdition(a);
+        var editionB = ExtractDistinctEdition(b);
+
+        if (editionA is not null && editionB is not null &&
+            !string.Equals(editionA, editionB, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return !HasUnrelatedTrailingSubtitle(a, normB) &&
+               !HasUnrelatedTrailingSubtitle(b, normA);
+    }
+
+    private static string? ExtractDistinctEdition(string name) =>
+        DistinctEditionSuffixRegex()
+                .Match(StripEditionSuffix(ApostropheVariantRegex().Replace(name, "'")))
+            is { Success: true } m
+            ? m.Groups[2].Value.ToLowerInvariant()
+            : null;
+
+    private static bool HasUnrelatedTrailingSubtitle(string raw, string otherNormalized)
+    {
+        var stripped = StripEditionSuffix(ApostropheVariantRegex().Replace(raw, "'"));
+
+        if (SubtitleSeparatorRegex().Match(stripped) is not { Success: true } match)
+            return false;
+
+        var subtitleWords = NormalizeName(match.Groups["subtitle"].Value)
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        if (subtitleWords.Length == 0)
+            return false;
+
+        var otherWords = new HashSet<string>(otherNormalized.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+        return subtitleWords.All(w => !otherWords.Contains(w));
     }
 
     private static string NormalizeNumerals(string name)
@@ -108,15 +178,29 @@ public static partial class GameNameHelper
                 return ParseRoman(w).ToString();
 
             var isLast = index == words.Length - 1;
-            var nextIsVariantCode = !isLast 
-                                    && words[index + 1].Length == 1 
+            var nextIsVariantCode = !isLast
+                                    && words[index + 1].Length == 1
                                     && char.IsLetter(words[index + 1][0]);
-            var prevLooksLikeSeries = index >= 1 
+            var prevLooksLikeSeries = index >= 1
                                       && words[index - 1].Length > 1;
 
             return isLast || nextIsVariantCode || prevLooksLikeSeries
                 ? ParseRoman(w).ToString()
                 : w;
         }));
+    }
+
+    private static int ParseRoman(string roman)
+    {
+        var result = 0;
+
+        for (var i = 0; i < roman.Length; i++)
+        {
+            var current = RomanValues[roman[i]];
+            var next = i + 1 < roman.Length ? RomanValues[roman[i + 1]] : 0;
+            result += current < next ? -current : current;
+        }
+
+        return result;
     }
 }

--- a/src/Restall.Application/UseCases/RefreshLibraryUseCase.cs
+++ b/src/Restall.Application/UseCases/RefreshLibraryUseCase.cs
@@ -37,7 +37,8 @@ public sealed class RefreshLibraryUseCase : IRefreshLibraryUseCase, ILightRefres
         _modCatalog = modCatalog;
     }
 
-    public async Task<RefreshLibraryResultDto> ExecuteFullRescanAsync(IProgress<GameScanProgressReportDto>? progress = null)
+    public async Task<RefreshLibraryResultDto> ExecuteFullRescanAsync(
+        IProgress<GameScanProgressReportDto>? progress = null)
     {
         var gameTask = _gameDetectionService.FindGamesAsync(progress);
         var versionTask = _versionCatalog.FetchVersionsAsync();
@@ -51,20 +52,25 @@ public sealed class RefreshLibraryUseCase : IRefreshLibraryUseCase, ILightRefres
         return await BuildResultAsync(games, gameScanResults.IsSuccess, gameScanResults.Message);
     }
 
-    public async Task<RefreshLibraryResultDto> ExecuteLightRescanAsync(IReadOnlyList<Game> existingGames, IProgress<GameScanProgressReportDto>? progress = null)
+    public async Task<RefreshLibraryResultDto> ExecuteLightRescanAsync(IReadOnlyList<Game> existingGames,
+        IProgress<GameScanProgressReportDto>? progress = null)
     {
         await Task.WhenAll(_versionCatalog.FetchVersionsAsync(), _modCatalog.FetchModsAsync());
 
         return await BuildResultAsync(existingGames.OrderBy(g => g.Name), true, null);
     }
 
-    private async Task<RefreshLibraryResultDto> BuildResultAsync(IOrderedEnumerable<Game> sortedGames, bool success, string? errorMessage)
+    private async Task<RefreshLibraryResultDto> BuildResultAsync(IOrderedEnumerable<Game> sortedGames, bool success,
+        string? errorMessage)
     {
         HashSet<Task> artworkTasks = [];
         List<GameInitResultDto> results = [];
 
         foreach (var game in sortedGames)
         {
+            if (string.IsNullOrWhiteSpace(game.Name))
+                continue;
+            
             var reShade = await _modDetectionService.DetectInstalledReShadeAsync(game.ExecutablePath!);
             var renoDx = await _modDetectionService.DetectInstalledRenoDXAsync(game.ExecutablePath!);
 
@@ -79,9 +85,11 @@ public sealed class RefreshLibraryUseCase : IRefreshLibraryUseCase, ILightRefres
                 ? _updateCheckService.CheckRenoDXUpdate(game.RenoDX)
                 : null;
 
-            var compatibleMod = FindCompatibleMod(game.Name, _modCatalog.GetRenoDXWikiMods());
+            var compatibleMod = FindCompatibleMod(GameNameHelper.StripCollectionPartSuffix(game.Name),
+                _modCatalog.GetRenoDXWikiMods());
             var compatibleGenericMod = compatibleMod is null
-                ? FindGenericMod(game.Name, _modCatalog.GetRenoDXGenericWikiMods())
+                ? FindGenericMod(GameNameHelper.StripCollectionPartSuffix(game.Name),
+                    _modCatalog.GetRenoDXGenericWikiMods())
                 : null;
 
             artworkTasks.Add(_gameArtworkService.EnrichGameArtworkAsync(game));
@@ -102,24 +110,32 @@ public sealed class RefreshLibraryUseCase : IRefreshLibraryUseCase, ILightRefres
 
     private static RenoDXModInfoDto? FindCompatibleMod(string? gameName, ImmutableArray<RenoDXModInfoDto> mods)
     {
-        if (string.IsNullOrWhiteSpace(gameName)) return null;
+        if (string.IsNullOrWhiteSpace(gameName))
+            return null;
 
-        var key = GameNameHelper.NormalizeName(gameName);
+        var candidates = mods.Where(m =>
+            GameNameHelper.IsLikelySameGame(gameName, m.Name)).ToList();
 
-        return mods.FirstOrDefault(m => m.Status != "💀" && GameNameHelper.NormalizeName(m.Name) == key)
-               ?? mods.FirstOrDefault(m =>
-                   m.Status != "💀" && GameNameHelper.FuzzyNameMatch(key, GameNameHelper.NormalizeName(m.Name)));
+        var normalizedGameName = GameNameHelper.NormalizeName(gameName);
+
+        return candidates.FirstOrDefault(m =>
+                   GameNameHelper.NormalizeName(m.Name) == normalizedGameName) ??
+               candidates.FirstOrDefault();
     }
 
     private static RenoDXGenericModInfoDto? FindGenericMod(string? gameName,
         ImmutableArray<RenoDXGenericModInfoDto> mods)
     {
-        if (string.IsNullOrWhiteSpace(gameName)) return null;
+        if (string.IsNullOrWhiteSpace(gameName))
+            return null;
 
-        var key = GameNameHelper.NormalizeName(gameName);
+        var candidates = mods.Where(m =>
+            GameNameHelper.IsLikelySameGame(gameName, m.Name)).ToList();
 
-        return mods.FirstOrDefault(m => m.Status != "💀" && GameNameHelper.NormalizeName(m.Name) == key)
-               ?? mods.FirstOrDefault(m =>
-                   m.Status != "💀" && GameNameHelper.FuzzyNameMatch(key, GameNameHelper.NormalizeName(m.Name)));
+        var normalizedGameName = GameNameHelper.NormalizeName(gameName);
+
+        return candidates.FirstOrDefault(m =>
+                   GameNameHelper.NormalizeName(m.Name) == normalizedGameName) ??
+               candidates.FirstOrDefault();
     }
 }

--- a/src/Restall.Infrastructure/Helpers/GameScanHelper.cs
+++ b/src/Restall.Infrastructure/Helpers/GameScanHelper.cs
@@ -99,6 +99,7 @@ internal static class GameScanHelper
             "install",
             "unins",
             "redist",
+            "DedicatedServer"
 
         };
 
@@ -117,7 +118,8 @@ internal static class GameScanHelper
             "DotNET",
             "__Installer",
             "_CommonRedist",
-            "UE_"
+            "UE_",
+            "Lossless Scaling"
             
         };
         if (nonGameArray.Any(k => name.Contains(k, StringComparison.OrdinalIgnoreCase)))

--- a/src/Restall.Infrastructure/Helpers/GameScanHelper.cs
+++ b/src/Restall.Infrastructure/Helpers/GameScanHelper.cs
@@ -145,13 +145,4 @@ internal static class GameScanHelper
         Path.Combine("bin", "x86"),
         Path.Combine("bin", "win64")
     ];
-    
-    internal static bool IsMassEffectLegendary(string? name)
-    => name is not null
-    && name.Contains("Mass Effect", StringComparison.OrdinalIgnoreCase)
-    && name.Contains("Legendary Edition", StringComparison.OrdinalIgnoreCase);
-    
-    
-    
-
 }

--- a/src/Restall.Infrastructure/Scanners/GameExpander.cs
+++ b/src/Restall.Infrastructure/Scanners/GameExpander.cs
@@ -12,9 +12,9 @@ internal static class GameExpander
         if (collection is null)
             return [game];
 
-        return collection.PartSuffixes.Select(part => new Game
+        return collection.Parts.Select(part => new Game
         {
-            Name = $"{game.Name} - {part}",
+            Name = $"{game.Name} - {part.DisplaySuffix}",
             InstallFolder = game.InstallFolder,
             ExecutablePath = collection.BuildExecutablePath(game, part),
             ThumbnailPathString = game.ThumbnailPathString,

--- a/src/Restall.Infrastructure/Scanners/GameExpander.cs
+++ b/src/Restall.Infrastructure/Scanners/GameExpander.cs
@@ -16,7 +16,7 @@ internal static class GameExpander
         {
             Name = $"{game.Name} - {part.DisplaySuffix}",
             InstallFolder = game.InstallFolder,
-            ExecutablePath = collection.BuildExecutablePath(game, part),
+            ExecutablePath = collection.BuildExecutablePath(game.InstallFolder!, part),
             ThumbnailPathString = game.ThumbnailPathString,
             PlatformName = game.PlatformName,
             PlatformId = game.PlatformId,

--- a/src/Restall.Infrastructure/Scanners/GameExpander.cs
+++ b/src/Restall.Infrastructure/Scanners/GameExpander.cs
@@ -1,5 +1,5 @@
+using Restall.Application.Helpers;
 using Restall.Domain.Entities;
-using Restall.Infrastructure.Helpers;
 
 namespace Restall.Infrastructure.Scanners;
 
@@ -7,21 +7,19 @@ internal static class GameExpander
 {
     internal static IEnumerable<Game> ExpandCollection(Game game)
     {
-        if (GameScanHelper.IsMassEffectLegendary(game.Name))
-        {
-            var meFolders = new[] {"ME1", "ME2", "ME3"};
-            return meFolders.Select(me => new Game
-            {
-                Name = $"{game.Name} - {me}",
-                InstallFolder = game.InstallFolder,
-                ExecutablePath = Path.Combine(game.InstallFolder!, "Game", me),
-                ThumbnailPathString = game.ThumbnailPathString,
-                PlatformName = game.PlatformName,
-                PlatformId = game.PlatformId,
-            });
+        var collection = GameCollectionCatalog.Find(game.Name);
 
-        }
-        
-        return [game];
+        if (collection is null)
+            return [game];
+
+        return collection.PartSuffixes.Select(part => new Game
+        {
+            Name = $"{game.Name} - {part}",
+            InstallFolder = game.InstallFolder,
+            ExecutablePath = collection.BuildExecutablePath(game, part),
+            ThumbnailPathString = game.ThumbnailPathString,
+            PlatformName = game.PlatformName,
+            PlatformId = game.PlatformId,
+        });
     }
 }

--- a/src/Restall.Infrastructure/Services/EngineDetectionService.cs
+++ b/src/Restall.Infrastructure/Services/EngineDetectionService.cs
@@ -131,7 +131,11 @@ internal sealed class EngineDetectionService : IEngineDetectionService
             if (depth > 4) continue;
             try
             {
-                if (Directory.GetFiles(dir, "*.exe").Length > 0) return dir;
+                if (Directory.GetFiles(dir, "*.exe")
+                    .Any(f => 
+                        !GameScanHelper.NonGameExecutable(Path.GetFileNameWithoutExtension(f))))
+                    return dir;
+                
                 foreach (var sub in Directory.GetDirectories(dir))
                 {
                     var folderName = Path.GetFileName(sub);

--- a/src/Restall.Infrastructure/Services/GameCoverService.cs
+++ b/src/Restall.Infrastructure/Services/GameCoverService.cs
@@ -254,9 +254,7 @@ internal sealed class GameCoverService : IGameCoverService
                     var titleProp = entry.TryGetProperty("title", out var title) ? title.GetString() :
                         entry.TryGetProperty("app_title", out var appTitle) ? appTitle.GetString() : null;
 
-                    if (!string.IsNullOrWhiteSpace(titleProp) &&
-                        GameNameHelper.FuzzyNameMatch(normalizedName,
-                            GameNameHelper.NormalizeName(titleProp)))
+                    if (!string.IsNullOrWhiteSpace(titleProp) && GameNameHelper.IsLikelySameGame(game.Name, titleProp))
                         bestMatch = entry;
                 }
             }


### PR DESCRIPTION
Makes wiki matching more robust.

### Overview of changes

* Wiki matching now properly separates subtitles on game titles (For instance RoboCop: Rogue City - Unfinished Business won't get falsely matched to RoboCop: Rogue City).
* Fixed app properly stripping possessive `'` but not `’` making games like "Assassin’s Creed® IV Black Flag™" on the RenoDX wiki fail to match to "Assassin's Creed IV Black Flag" on disk (note the `’` instead of `'`).
* Separated edition suffixes into two separate Regex definitions. One for editions we actually want to strip (usually collections with bundled DLC) and one that usually indicate a game with a different architecture that we want to match separately to the original game.
* Added in-memory collection definitions for games that are collections. This makes it easier to share game collection data between game name matching and the expander used to expand the collection in the game list in the app. It keeps both callers in sync and makes it easier to add new game collections with an easy toggle if the collection should be collapsed back or not for game name matching.
* Add more entries to non-game list fixing an issue with pathing for Fallout New Vegas on Epic.
* Increase the strictness of fuzzy name match. This stops for instance "The Forest" getting falsely matched to "Sons of the Forest".