### PR TITLE
Os separation logic

### DIFF
--- a/src/Restall.Application/Helpers/GameNameHelper.cs
+++ b/src/Restall.Application/Helpers/GameNameHelper.cs
@@ -14,7 +14,7 @@ public static partial class GameNameHelper
     private static partial Regex NonWordCharsRegex();
 
     [GeneratedRegex(
-        @"(\s*[-–:]\s*|\s+)(ultimate|complete|gold|deluxe|premium|anniversary|directors cut|goty|game of the year|standard)(\s+edition)?\s*$",
+        @"(\s*[-–:]\s*|\s+)(20 year celebration|ultimate|complete|gold|deluxe|premium|anniversary|directors cut|goty|game of the year|standard)(\s+edition)?\s*$",
         RegexOptions.IgnoreCase)]
     private static partial Regex EditionSuffixRegex();
 

--- a/src/Restall.Application/Interfaces/Driven/IPathService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IPathService.cs
@@ -15,6 +15,12 @@ public interface IPathService
     string GetArtworkCacheDirectory();
     string GetGameArtworkCover(string slug);
     string GetGameArtThumbnailPath(string slug);
+
+    string GetEpicInstallPath();
+    string GetEpicHeroicPath();
+    string GetGOGHeroicPath();
     
     string GetDefaultLogPath();
+    
+    
 }

--- a/src/Restall.Application/Interfaces/Driven/IPathService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IPathService.cs
@@ -16,6 +16,7 @@ public interface IPathService
     string GetGameArtworkCover(string slug);
     string GetGameArtThumbnailPath(string slug);
 
+    IReadOnlyList<string> GetSteamLinuxPaths();
     string GetEpicInstallPath();
     string GetEpicHeroicPath();
     string GetGOGHeroicPath();

--- a/src/Restall.Application/Interfaces/Driven/IPathService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IPathService.cs
@@ -19,6 +19,8 @@ public interface IPathService
     IReadOnlyList<string> GetSteamLinuxPaths();
     string GetEpicInstallPath();
     string GetHeroicPath();
+    string GetHeroicInstalledPath(Game.Platform platform);
+    string GetHeroicStoreCache(Game.Platform platform, string destination);
     string GetDefaultLogPath();
     
     

--- a/src/Restall.Application/Interfaces/Driven/IPathService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IPathService.cs
@@ -18,9 +18,7 @@ public interface IPathService
 
     IReadOnlyList<string> GetSteamLinuxPaths();
     string GetEpicInstallPath();
-    string GetEpicHeroicPath();
-    string GetGOGHeroicPath();
-    
+    string GetHeroicPath();
     string GetDefaultLogPath();
     
     

--- a/src/Restall.Infrastructure/Helpers/GameScanHelper.cs
+++ b/src/Restall.Infrastructure/Helpers/GameScanHelper.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Versioning;
 using Microsoft.Win32;
 using System.Text.RegularExpressions;
 
@@ -24,7 +25,7 @@ internal static class GameScanHelper
         Regex.Match(json, $@"""{Regex.Escape(key)}""\s*:\s*""([^""\\]*(\\.[^""\\]*)*)""")
             is { Success: true } m ? NormalizePath(m.Groups[1].Value.Replace("\\\\", "\\").Replace("\\/", "/")) : null;
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Already checked at call site")]
+    [SupportedOSPlatform("windows")]
     internal static string? ReadRegistry(string keyPath, string valueName)
     {
         try
@@ -33,11 +34,11 @@ internal static class GameScanHelper
 
             using var currentUserKey =  Registry.CurrentUser.OpenSubKey(fullPath);
             var value =  currentUserKey?.GetValue(valueName) as string;
-            if (value != null) return value;
+            if (value is not null) return value;
             
             using var localMachineKey = Registry.LocalMachine.OpenSubKey(fullPath);
             value  = localMachineKey?.GetValue(valueName) as string;
-            if(value != null) return value;
+            if(value is not null) return value;
             
             var wow64Path = fullPath.Replace(s_softwareRegistryPath, s_wow64RegistryPath);
             using var wow64Key = Registry.LocalMachine.OpenSubKey(wow64Path);
@@ -47,7 +48,7 @@ internal static class GameScanHelper
         catch { return null; }
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Already checked at call site")]
+    [SupportedOSPlatform("windows")]
     internal static RegistryKey? GetOpenRegistryKey(string keyPath)
     {
         try
@@ -57,7 +58,7 @@ internal static class GameScanHelper
                 : s_softwareRegistryPath + keyPath;
             
             var key = Registry.LocalMachine.OpenSubKey(fullPath);
-            if (key != null) return key;
+            if (key is not null) return key;
             
             var wow64Path = fullPath.Replace(s_softwareRegistryPath, s_wow64RegistryPath);
             return Registry.LocalMachine.OpenSubKey(wow64Path);
@@ -99,6 +100,7 @@ internal static class GameScanHelper
             "install",
             "unins",
             "redist",
+            "Dedicated Server"
 
         };
 
@@ -117,7 +119,8 @@ internal static class GameScanHelper
             "DotNET",
             "__Installer",
             "_CommonRedist",
-            "UE_"
+            "UE_",
+            "Lossless Scaling"
             
         };
         if (nonGameArray.Any(k => name.Contains(k, StringComparison.OrdinalIgnoreCase)))

--- a/src/Restall.Infrastructure/Helpers/RegexHelper.cs
+++ b/src/Restall.Infrastructure/Helpers/RegexHelper.cs
@@ -9,10 +9,10 @@ internal static partial class RegexHelper
     internal static Regex SteamLibraryRegex => SteamLibrary();
     internal static Regex HeroicGameBlockRegex => HeroicGameBlock();
     internal static Regex HeroicInstallPathRegex => HeroicInstallPath();
-    internal static Regex HeroicTitleRegex => HeroicTitle();
     internal static Regex GOGHeroicAppNameRegex => HeroicAppNameGOG();
     internal static Regex EpicHeroicAppNameRegex => HeroicAppNameEpic();
     internal static Regex Match32BitRegex => Match32Bit();
+    internal static Regex InstallInfoAppNameAndTitleRegex => InstallInfoAppNameAndTitle();
 
     [GeneratedRegex(@"\b32[\s-]?bit\b", RegexOptions.IgnoreCase)]
     private static partial Regex Match32Bit();
@@ -38,6 +38,8 @@ internal static partial class RegexHelper
     [GeneratedRegex(@"""install_path""\s*:\s*""([^""]+)""")]
     private static partial Regex HeroicInstallPath();
     
-    [GeneratedRegex(@"""title""\s*:\s*""([^""]+)""")]
-    private static partial Regex HeroicTitle();
+    [GeneratedRegex(@"""[^""]+""\s*:\s*\{\s*""game""\s*:\s*\{\s*""app_name""\s*:\s*""([^""]+)""\s*,\s*""title""\s*:\s*""([^""]+)""")]
+    private static partial Regex InstallInfoAppNameAndTitle();
+
+
 }

--- a/src/Restall.Infrastructure/Scanners/EAScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/EAScanner.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Versioning;
 using Restall.Application.DTOs.Results;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;
@@ -37,6 +38,7 @@ internal sealed class EAScanner : IPlatformScannerService
     }
 
     //TODO: ADD PUBLISH KEYS HELPER/MANIFEST TO INCLUDE MANY DIFFERENT REGEDITS
+    [SupportedOSPlatform("windows")]
     private (List<Game>games, string? error) ScanEALibrary()
     {
         var games = new List<Game>();
@@ -45,7 +47,7 @@ internal sealed class EAScanner : IPlatformScannerService
             using var key = GameScanHelper.GetOpenRegistryKey(@"\EA Games");
 
             if (key is null) return (games,null);
-#pragma warning disable CA1416 // Already checked before method is called
+
             foreach (var subName in key.GetSubKeyNames())
             {
                 using var gameKey = key.OpenSubKey(subName);

--- a/src/Restall.Infrastructure/Scanners/EpicScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/EpicScanner.cs
@@ -9,10 +9,13 @@ namespace Restall.Infrastructure.Scanners;
 internal sealed class EpicScanner : IPlatformScannerService
 {
     private readonly ILogService _logService;
+    private readonly IPathService _pathService;
 
-    public EpicScanner(ILogService logService)
+    public EpicScanner(ILogService logService, 
+        IPathService pathService)
     {
         _logService = logService;
+        _pathService = pathService;
     }
 
     public Task<GameScanResultDto> ScanAsync() => Task.Run(ScanEpic);
@@ -25,8 +28,8 @@ internal sealed class EpicScanner : IPlatformScannerService
 
         if (OperatingSystem.IsWindows())
         {
-            var ueInstallPath = GetInstallPath();
-            if (ueInstallPath is not null && Directory.Exists(ueInstallPath))
+            var ueInstallPath = _pathService.GetEpicInstallPath();
+            if (Directory.Exists(ueInstallPath))
             {
                 var (epicLibrary, error) = ScanEpicLibrary(ueInstallPath);
                 games.AddRange(epicLibrary);
@@ -34,9 +37,9 @@ internal sealed class EpicScanner : IPlatformScannerService
             }
         }
 
-        var epicHeroicPath = GetHeroicInstallPath();
+        var epicHeroicPath = _pathService.GetEpicHeroicPath();
 
-        if (epicHeroicPath is not null && Directory.Exists(epicHeroicPath))
+        if (Directory.Exists(epicHeroicPath))
         {
             var (epicHeroicLibrary, error) = ScanHeroicLibrary(epicHeroicPath);
             games.AddRange(epicHeroicLibrary);
@@ -50,12 +53,12 @@ internal sealed class EpicScanner : IPlatformScannerService
             Message: errors.Count > 0 ? string.Join(", ", errors) : null);
     }
 
-    private string? GetInstallPath()
-    {
-        return Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-            "Epic", "EpicGamesLauncher", "Data", "Manifests");
-    }
+    // private string? GetInstallPath()
+    // {
+    //     return Path.Combine(
+    //         Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+    //         "Epic", "EpicGamesLauncher", "Data", "Manifests");
+    // }
 
     private (List<Game> games, string? error) ScanEpicLibrary(string manifestDir)
     {
@@ -96,16 +99,16 @@ internal sealed class EpicScanner : IPlatformScannerService
         return (games, null);
     }
 
-    private string? GetHeroicInstallPath()
-    {
-        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-
-        var heroicPath = OperatingSystem.IsWindows()
-            ? Path.Combine(home, "AppData", "Roaming", "heroic", "legendaryConfig", "legendary")
-            : Path.Combine(home, ".config", "heroic", "legendaryConfig", "legendary");
-
-        return Directory.Exists(heroicPath) ? heroicPath : null;
-    }
+    // private string? GetHeroicInstallPath()
+    // {
+    //     var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+    //
+    //     var heroicPath = OperatingSystem.IsWindows()
+    //         ? Path.Combine(home, "AppData", "Roaming", "heroic", "legendaryConfig", "legendary")
+    //         : Path.Combine(home, ".config", "heroic", "legendaryConfig", "legendary");
+    //
+    //     return Directory.Exists(heroicPath) ? heroicPath : null;
+    // }
 
     private (List<Game>games, string? error) ScanHeroicLibrary(string configDir)
     {

--- a/src/Restall.Infrastructure/Scanners/EpicScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/EpicScanner.cs
@@ -42,7 +42,7 @@ internal sealed class EpicScanner : IPlatformScannerService
 
         if (Directory.Exists(epicHeroicPath))
         {
-            var (epicHeroicLibrary, error) = ScanHeroicLibrary(epicHeroicPath);
+            var (epicHeroicLibrary, error) = ScanHeroicLibrary();
             games.AddRange(epicHeroicLibrary);
             if (error is not null) errors.Add(error);
         }
@@ -94,12 +94,12 @@ internal sealed class EpicScanner : IPlatformScannerService
     }
 
 
-    private (List<Game>games, string? error) ScanHeroicLibrary(string configDir)
+    private (List<Game>games, string? error) ScanHeroicLibrary()
     {
         var games = new List<Game>();
-        var installedJsonPath = Path.Combine(configDir, "legendaryConfig", "legendary", "installed.json");
-        var installedInstallInfoPath = Path.Combine(configDir, "store_cache", "legendary_install_info.json");
-        
+        var installedJsonPath = _pathService.GetHeroicInstalledPath(Platform);
+        var installedInstallInfoPath = _pathService.GetHeroicStoreCache(Platform, "legendary_install_info.json");
+
         if (!File.Exists(installedJsonPath) || !File.Exists(installedInstallInfoPath)) return (games, null);
 
         var installInfoGames = new Dictionary<string, string>();

--- a/src/Restall.Infrastructure/Scanners/EpicScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/EpicScanner.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;
 using Restall.Infrastructure.Helpers;

--- a/src/Restall.Infrastructure/Scanners/EpicScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/EpicScanner.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;
 using Restall.Infrastructure.Helpers;
@@ -11,7 +12,7 @@ internal sealed class EpicScanner : IPlatformScannerService
     private readonly ILogService _logService;
     private readonly IPathService _pathService;
 
-    public EpicScanner(ILogService logService, 
+    public EpicScanner(ILogService logService,
         IPathService pathService)
     {
         _logService = logService;
@@ -37,7 +38,7 @@ internal sealed class EpicScanner : IPlatformScannerService
             }
         }
 
-        var epicHeroicPath = _pathService.GetEpicHeroicPath();
+        var epicHeroicPath = _pathService.GetHeroicPath();
 
         if (Directory.Exists(epicHeroicPath))
         {
@@ -52,13 +53,6 @@ internal sealed class EpicScanner : IPlatformScannerService
             IsSuccess: games.Count > 0,
             Message: errors.Count > 0 ? string.Join(", ", errors) : null);
     }
-
-    // private string? GetInstallPath()
-    // {
-    //     return Path.Combine(
-    //         Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
-    //         "Epic", "EpicGamesLauncher", "Data", "Manifests");
-    // }
 
     private (List<Game> games, string? error) ScanEpicLibrary(string manifestDir)
     {
@@ -75,7 +69,7 @@ internal sealed class EpicScanner : IPlatformScannerService
 
                 if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(rootPath))
                     continue;
-                
+
                 if (!Directory.Exists(rootPath))
                     continue;
 
@@ -99,26 +93,34 @@ internal sealed class EpicScanner : IPlatformScannerService
         return (games, null);
     }
 
-    // private string? GetHeroicInstallPath()
-    // {
-    //     var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-    //
-    //     var heroicPath = OperatingSystem.IsWindows()
-    //         ? Path.Combine(home, "AppData", "Roaming", "heroic", "legendaryConfig", "legendary")
-    //         : Path.Combine(home, ".config", "heroic", "legendaryConfig", "legendary");
-    //
-    //     return Directory.Exists(heroicPath) ? heroicPath : null;
-    // }
 
     private (List<Game>games, string? error) ScanHeroicLibrary(string configDir)
     {
         var games = new List<Game>();
-        var installedJsonPath = Path.Combine(configDir, "installed.json");
+        var installedJsonPath = Path.Combine(configDir, "legendaryConfig", "legendary", "installed.json");
+        var installedInstallInfoPath = Path.Combine(configDir, "store_cache", "legendary_install_info.json");
+        
+        if (!File.Exists(installedJsonPath) || !File.Exists(installedInstallInfoPath)) return (games, null);
 
-
-        if (!File.Exists(installedJsonPath)) return (games, null);
-
+        var installInfoGames = new Dictionary<string, string>();
         string json;
+
+        try
+        {
+            var infoJson = File.ReadAllText(installedInstallInfoPath);
+
+            foreach (Match match in RegexHelper.InstallInfoAppNameAndTitleRegex.Matches(infoJson))
+            {
+                var appName = match.Groups[1].Value;
+                var title = match.Groups[2].Value;
+
+                installInfoGames[appName] = title;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logService.LogError($"Failed to read legendary_install_info.json file in Epic Heroic library", ex);
+        }
 
         try
         {
@@ -135,34 +137,34 @@ internal sealed class EpicScanner : IPlatformScannerService
             try
             {
                 var blockValue = match.Value;
-                var installPath = RegexHelper.HeroicInstallPathRegex.Match(blockValue)
-                    is { Success: true } pm
-                    ? pm.Groups[1].Value.Replace("\\\\", "\\")
-                    : null;
-                installPath = GameScanHelper.NormalizePath(installPath);
-                if (string.IsNullOrEmpty(installPath)) continue;
 
-                var title = RegexHelper.HeroicTitleRegex.Match(blockValue)
-                    is { Success: true } tm
-                    ? tm.Groups[1].Value
-                    : null;
-
-                var name = !string.IsNullOrWhiteSpace(title)
-                    ? title
-                    : Path.GetFileName(installPath);
-
-                if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(installPath)) continue;
-
+                var isDlcMatch = Regex.IsMatch(blockValue, @"""is_dlc""\s*:\s*true", RegexOptions.IgnoreCase);
+                
+                if (isDlcMatch) continue;
+                
                 var appName = RegexHelper.EpicHeroicAppNameRegex.Match(blockValue)
                     is { Success: true } am
                     ? am.Groups[1].Value
                     : null;
 
+                if (string.IsNullOrEmpty(appName)) continue;
+
+                if (!installInfoGames.TryGetValue(appName, out var title)) continue;
+
+                var installPath = RegexHelper.HeroicInstallPathRegex.Match(blockValue)
+                    is { Success: true } pm
+                    ? pm.Groups[1].Value.Replace("\\\\", "\\")
+                    : null;
+
+                installPath = GameScanHelper.NormalizePath(installPath);
+
+                if (string.IsNullOrEmpty(installPath)) continue;
+
                 games.Add(new Game
                 {
-                    Name = name,
+                    Name = title,
                     InstallFolder = installPath,
-                    PlatformName = Game.Platform.Epic,
+                    PlatformName = Platform,
                     PlatformId = appName
                 });
             }
@@ -171,7 +173,6 @@ internal sealed class EpicScanner : IPlatformScannerService
                 _logService.LogError($"Failed to scan the json block in Epic Heroic library", ex);
             }
         }
-
 
         return (games, null);
     }

--- a/src/Restall.Infrastructure/Scanners/GOGScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/GOGScanner.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Versioning;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;
 using Restall.Infrastructure.Helpers;
@@ -9,10 +10,13 @@ namespace Restall.Infrastructure.Scanners;
 internal sealed class GOGScanner : IPlatformScannerService
 {
     private readonly ILogService _logService;
+    private readonly IPathService _pathService;
 
-    public GOGScanner(ILogService logService)
+    public GOGScanner(ILogService logService,
+        IPathService pathService)
     {
         _logService = logService;
+        _pathService = pathService;
     }
 
     public Task<GameScanResultDto> ScanAsync() => Task.Run(ScanGOG);
@@ -29,8 +33,8 @@ internal sealed class GOGScanner : IPlatformScannerService
             if (error is not null) errors.Add(error);
         }
 
-        var gogHeroicPath = GetHeroicInstallPath();
-        if (gogHeroicPath is not null && Directory.Exists(gogHeroicPath))
+        var gogHeroicPath = _pathService.GetGOGHeroicPath();
+        if (Directory.Exists(gogHeroicPath))
         {
             var (heroicGames, error) = ScanHeroicLibrary(gogHeroicPath);
             games.AddRange(heroicGames);
@@ -43,7 +47,7 @@ internal sealed class GOGScanner : IPlatformScannerService
             IsSuccess: games.Count > 0,
             Message: errors.Count > 0 ? string.Join(", ", errors) : null);
     }
-
+    [SupportedOSPlatform("windows")]
     private (List<Game> games, string? error) ScanGOGLibrary()
     {
         var games = new List<Game>();
@@ -53,15 +57,14 @@ internal sealed class GOGScanner : IPlatformScannerService
 
         if (key is null) return (games, null);
 
-#pragma warning disable CA1416 // Already checked before method is called
+
         foreach (var subName in key.GetSubKeyNames())
         {
             try
             {
                 using var gameKey = key.OpenSubKey(subName);
                 if (gameKey is null) continue;
-
-                //Value patterns in registry
+                
                 var name = GameScanHelper.GetRegistryValue(gameKey, "GAMENAME", "GameName", "gameName");
                 var path = GameScanHelper.GetRegistryValue(gameKey, "PATH", "path");
 
@@ -86,16 +89,16 @@ internal sealed class GOGScanner : IPlatformScannerService
         return (games, null);
     }
 
-    private string? GetHeroicInstallPath()
-    {
-        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        
-        var heroicPath = OperatingSystem.IsWindows()
-            ? Path.Combine(home, "AppData", "Roaming", "heroic", "gog_store")
-            : Path.Combine(home, ".config", "heroic", "gog_store");
-
-        return Directory.Exists(heroicPath) ? heroicPath : null;
-    }
+    // private string? GetHeroicInstallPath()
+    // {
+    //     var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+    //     
+    //     var heroicPath = OperatingSystem.IsWindows()
+    //         ? Path.Combine(home, "AppData", "Roaming", "heroic", "gog_store")
+    //         : Path.Combine(home, ".config", "heroic", "gog_store");
+    //
+    //     return Directory.Exists(heroicPath) ? heroicPath : null;
+    // }
 
     private (List<Game> games, string? error) ScanHeroicLibrary(string configDir)
     {

--- a/src/Restall.Infrastructure/Scanners/GOGScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/GOGScanner.cs
@@ -1,4 +1,5 @@
 using System.Runtime.Versioning;
+using System.Text.Json;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;
 using Restall.Infrastructure.Helpers;
@@ -32,8 +33,9 @@ internal sealed class GOGScanner : IPlatformScannerService
             games.AddRange(gogGames);
             if (error is not null) errors.Add(error);
         }
-
-        var gogHeroicPath = _pathService.GetGOGHeroicPath();
+        
+        var gogHeroicPath = _pathService.GetHeroicPath();
+        
         if (Directory.Exists(gogHeroicPath))
         {
             var (heroicGames, error) = ScanHeroicLibrary(gogHeroicPath);
@@ -47,6 +49,7 @@ internal sealed class GOGScanner : IPlatformScannerService
             IsSuccess: games.Count > 0,
             Message: errors.Count > 0 ? string.Join(", ", errors) : null);
     }
+
     [SupportedOSPlatform("windows")]
     private (List<Game> games, string? error) ScanGOGLibrary()
     {
@@ -64,7 +67,7 @@ internal sealed class GOGScanner : IPlatformScannerService
             {
                 using var gameKey = key.OpenSubKey(subName);
                 if (gameKey is null) continue;
-                
+
                 var name = GameScanHelper.GetRegistryValue(gameKey, "GAMENAME", "GameName", "gameName");
                 var path = GameScanHelper.GetRegistryValue(gameKey, "PATH", "path");
 
@@ -89,25 +92,34 @@ internal sealed class GOGScanner : IPlatformScannerService
         return (games, null);
     }
 
-    // private string? GetHeroicInstallPath()
-    // {
-    //     var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-    //     
-    //     var heroicPath = OperatingSystem.IsWindows()
-    //         ? Path.Combine(home, "AppData", "Roaming", "heroic", "gog_store")
-    //         : Path.Combine(home, ".config", "heroic", "gog_store");
-    //
-    //     return Directory.Exists(heroicPath) ? heroicPath : null;
-    // }
 
     private (List<Game> games, string? error) ScanHeroicLibrary(string configDir)
     {
         var games = new List<Game>();
-        var installedJsonPath = Path.Combine(configDir, "installed.json");
+        var installedJsonPath = Path.Combine(configDir, "gog_store", "installed.json");
+        var installedInstallInfoPath = Path.Combine(configDir, "store_cache", "gog_install_info.json");
 
-        if (!File.Exists(installedJsonPath)) return (games, null);
-
+        if (!File.Exists(installedJsonPath) || !File.Exists(installedInstallInfoPath)) return (games, null);
+        
+        var installInfoGames = new Dictionary<string, string>();
         string json;
+
+        try
+        {
+            var infoJson = File.ReadAllText(installedInstallInfoPath);
+
+            foreach (Match match in RegexHelper.InstallInfoAppNameAndTitleRegex.Matches(infoJson))
+            {
+                var appName = match.Groups[1].Value;
+                var title = match.Groups[2].Value;
+
+                installInfoGames[appName] = title;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logService.LogError($"Failed to read gog_install_info.json file in GOG Heroic library", ex);
+        }
 
         try
         {
@@ -119,51 +131,43 @@ internal sealed class GOGScanner : IPlatformScannerService
             return (games, $"Failed to read installed.json file in GOG Heroic library.");
         }
 
-
         foreach (Match match in RegexHelper.HeroicGameBlockRegex.Matches(json))
         {
             try
             {
                 var blockValue = match.Value;
 
-                var installPath = RegexHelper.HeroicInstallPathRegex.Match(blockValue)
-                    is { Success: true } pm
-                    ? pm.Groups[1].Value.Replace("\\\\", "\\")
-                    : null;
-
-                installPath = GameScanHelper.NormalizePath(installPath);
-                if (string.IsNullOrEmpty(installPath) || !Directory.Exists(installPath)) continue;
-
-                var title = RegexHelper.HeroicTitleRegex.Match(blockValue)
-                    is { Success: true } tm
-                    ? tm.Groups[1].Value
-                    : null;
-
-                var name = !string.IsNullOrWhiteSpace(title)
-                    ? title
-                    : Path.GetFileName(installPath);
-
-                if (string.IsNullOrEmpty(name)) continue;
-
                 var appName = RegexHelper.GOGHeroicAppNameRegex.Match(blockValue)
                     is { Success: true } am
                     ? am.Groups[1].Value
                     : null;
 
+                if (string.IsNullOrEmpty(appName)) continue;
+
+                if (!installInfoGames.TryGetValue(appName, out var title)) continue;
+
+                var installPath = RegexHelper.HeroicInstallPathRegex.Match(blockValue)
+                    is { Success: true } pm
+                    ? pm.Groups[1].Value.Replace("\\\\", "\\")
+                    : null;
+
+
+                installPath = GameScanHelper.NormalizePath(installPath);
+                if (string.IsNullOrEmpty(installPath)) continue;
+
                 games.Add(new Game
                 {
-                    Name = name,
+                    Name = title,
                     InstallFolder = installPath,
-                    PlatformName = Game.Platform.GOG,
+                    PlatformName = Platform,
                     PlatformId = appName
                 });
             }
             catch (Exception ex)
             {
-                _logService.LogError($"Failed to scan the json block in GOG Heroic library", ex);
+                _logService.LogError($"Failed to scan the json block in GOG library", ex);
             }
         }
-
 
         return (games, null);
     }

--- a/src/Restall.Infrastructure/Scanners/GOGScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/GOGScanner.cs
@@ -1,5 +1,4 @@
 using System.Runtime.Versioning;
-using System.Text.Json;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;
 using Restall.Infrastructure.Helpers;
@@ -103,7 +102,8 @@ internal sealed class GOGScanner : IPlatformScannerService
         
         var installInfoGames = new Dictionary<string, string>();
         string json;
-
+        
+        //TODO: Consider Regex vs JSON in both Epic and GOG Scanners
         try
         {
             var infoJson = File.ReadAllText(installedInstallInfoPath);

--- a/src/Restall.Infrastructure/Scanners/GOGScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/GOGScanner.cs
@@ -38,7 +38,7 @@ internal sealed class GOGScanner : IPlatformScannerService
         
         if (Directory.Exists(gogHeroicPath))
         {
-            var (heroicGames, error) = ScanHeroicLibrary(gogHeroicPath);
+            var (heroicGames, error) = ScanHeroicLibrary();
             games.AddRange(heroicGames);
             if (error is not null) errors.Add(error);
         }
@@ -93,11 +93,11 @@ internal sealed class GOGScanner : IPlatformScannerService
     }
 
 
-    private (List<Game> games, string? error) ScanHeroicLibrary(string configDir)
+    private (List<Game> games, string? error) ScanHeroicLibrary()
     {
         var games = new List<Game>();
-        var installedJsonPath = Path.Combine(configDir, "gog_store", "installed.json");
-        var installedInstallInfoPath = Path.Combine(configDir, "store_cache", "gog_install_info.json");
+        var installedJsonPath = _pathService.GetHeroicInstalledPath(Platform);
+        var installedInstallInfoPath = _pathService.GetHeroicStoreCache(Platform, "gog_install_info.json");
 
         if (!File.Exists(installedJsonPath) || !File.Exists(installedInstallInfoPath)) return (games, null);
         

--- a/src/Restall.Infrastructure/Scanners/SteamScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/SteamScanner.cs
@@ -9,10 +9,14 @@ namespace Restall.Infrastructure.Scanners;
 internal sealed class SteamScanner : IPlatformScannerService
 {
     private readonly ILogService _logService;
+    private readonly IPathService _pathService;
     
-    public SteamScanner(ILogService logService)
+    public SteamScanner(ILogService logService,
+        IPathService pathService)
     {
         _logService = logService;
+        _pathService = pathService;
+        
     }
     
     public Task<GameScanResultDto> ScanAsync() => Task.Run(ScanSteam);
@@ -51,21 +55,9 @@ internal sealed class SteamScanner : IPlatformScannerService
             Message: errors.Count > 0 ? string.Join(", ", errors) : null);
     }
 
-    private string? GetInstallPath()
-    {
-        if (OperatingSystem.IsWindows()) return GameScanHelper.ReadRegistry(@"Valve\Steam", "SteamPath");
-        
-        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        //TODO: DEFINE THESE IN PATHSERVICE TO HAVE A CENTRALIZED STATE SERVICE
-        var linuxPaths = new[]
-        {
-            Path.Combine(home, ".steam", "steam"),
-            Path.Combine(home, ".local", "share", "Steam"),
-            Path.Combine(home, "snap",   "steam", "common", ".local", "share", "Steam")
-        };
-        
-        return linuxPaths.FirstOrDefault(Directory.Exists);
-    }
+    private string? GetInstallPath() =>
+        OperatingSystem.IsWindows() ? GameScanHelper.ReadRegistry(@"Valve\Steam", "SteamPath") : 
+            _pathService.GetSteamLinuxPaths().FirstOrDefault(Directory.Exists);
 
     private (List<Game> games, string? error) ScanSteamLibrary(string library)
     {

--- a/src/Restall.Infrastructure/Scanners/UbisoftScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/UbisoftScanner.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Versioning;
 using Restall.Application.DTOs.Results;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;
@@ -37,7 +38,7 @@ internal sealed class UbisoftScanner : IPlatformScannerService
             Message: errors.Count > 0 ? string.Join(", ", errors) : null);
         
     }
-    
+    [SupportedOSPlatform("windows")]
     private (List<Game> games, string? error) ScanUbisoftLibrary()
     {
         var games = new List<Game>();
@@ -47,7 +48,7 @@ internal sealed class UbisoftScanner : IPlatformScannerService
             using var key = GameScanHelper.GetOpenRegistryKey(@"\Ubisoft\Launcher\Installs");
             if (key is null) return (games, null);
 
-#pragma warning disable CA1416 // Handled before method is called
+
             foreach (var subName in key.GetSubKeyNames())
             {
                 using var gameKey = key.OpenSubKey(subName);

--- a/src/Restall.Infrastructure/Services/GameCoverService.cs
+++ b/src/Restall.Infrastructure/Services/GameCoverService.cs
@@ -11,6 +11,7 @@ internal sealed class GameCoverService : IGameCoverService
     private readonly ILogService _logService;
     private readonly HttpClient _httpClient;
     private readonly IImageResizeService _imageResizeService;
+    private readonly IPathService _pathService;
     
     private const string PcgwCargoByPageNameUrl =
         "https://www.pcgamingwiki.com/w/api.php?action=cargoquery&tables=Infobox_game&fields=Infobox_game.Cover_URL&where=Infobox_game._pageName%3D%22{0}%22&format=json";
@@ -23,11 +24,13 @@ internal sealed class GameCoverService : IGameCoverService
 
     public GameCoverService(ILogService logService,
         HttpClient httpClient,
-        IImageResizeService imageResizeService)
+        IImageResizeService imageResizeService,
+        IPathService pathService)
     {
         _logService = logService;
         _httpClient = httpClient;
         _imageResizeService = imageResizeService;
+        _pathService = pathService;
     }
 
     public async Task DownloadCoverIfMissingAsync(Game game, string coverPath)
@@ -115,7 +118,7 @@ internal sealed class GameCoverService : IGameCoverService
         return null;
     }
 
-    private static string? FindSteamRoot()
+    private string? FindSteamRoot()
     {
         if (OperatingSystem.IsWindows())
         {
@@ -128,19 +131,8 @@ internal sealed class GameCoverService : IGameCoverService
             if (Directory.Exists(defaultPath)) return defaultPath;
         }
 
-        if (OperatingSystem.IsLinux())
-        {
-            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            var linuxPaths = new[]
-            {
-                Path.Combine(home, ".steam", "steam"),
-                Path.Combine(home, ".local", "share", "Steam"),
-                Path.Combine(home, "snap", "steam", "common", ".local", "share", "Steam")
-            };
-            return linuxPaths.FirstOrDefault(Directory.Exists);
-        }
-
-        return null;
+        return OperatingSystem.IsLinux() ? 
+            _pathService.GetSteamLinuxPaths().FirstOrDefault(Directory.Exists) : null;
     }
     
     // GOG ---------------------------------------------------------------------------------

--- a/src/Restall.Infrastructure/Services/GameCoverService.cs
+++ b/src/Restall.Infrastructure/Services/GameCoverService.cs
@@ -209,18 +209,12 @@ internal sealed class GameCoverService : IGameCoverService
     // Heroic (GOG + Epic) -----------------------------------------------------------------
     private async Task<string?> TryResolveHeroicCoverAsync(Game game)
     {
-        var heroicPath = GetHeroicConfigPath();
-        if (heroicPath is null) return null;
-
+        
         var isGog = game.PlatformName == Game.Platform.GOG;
-        var cacheFile = Path.Combine(heroicPath, "store_cache",
-            isGog ? "gog_library.json" : "legendary_library.json");
-
+        var cacheFile = _pathService.GetHeroicStoreCache(game.PlatformName, isGog ? "gog_library.json" : "legendary_library.json");
+            
         if (!File.Exists(cacheFile)) return null;
-
-        var gameId = game.PlatformId ?? string.Empty;
-        var normalizedName = GameNameHelper.NormalizeName(game.Name ?? string.Empty);
-
+        
         try
         {
             var json = await File.ReadAllTextAsync(cacheFile);
@@ -234,12 +228,6 @@ internal sealed class GameCoverService : IGameCoverService
 
             foreach (var entry in library.EnumerateArray())
             {
-                if (entry.TryGetProperty("app_name", out var appName)
-                    && string.Equals(appName.GetString(), gameId, StringComparison.OrdinalIgnoreCase))
-                {
-                    bestMatch = entry;
-                    break;
-                }
 
                 if (bestMatch is null)
                 {
@@ -267,16 +255,6 @@ internal sealed class GameCoverService : IGameCoverService
         }
 
         return null;
-    }
-
-    private static string? GetHeroicConfigPath()
-    {
-        if (OperatingSystem.IsWindows())
-            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "heroic");
-
-        return OperatingSystem.IsLinux()
-            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "heroic")
-            : null;
     }
     
     // PCGamingWiki (fallback) -------------------------------------------------------------

--- a/src/Restall.Infrastructure/Services/PathService.cs
+++ b/src/Restall.Infrastructure/Services/PathService.cs
@@ -11,6 +11,7 @@ internal sealed class PathService : IPathService
     private static readonly string s_userProfileDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
     private static readonly string s_commonAppDataDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
     
+    
     private const string s_downloadCacheFolderName = "DownloadCache";
     private const string s_cacheFolderName = "Cache";
     private const string s_artworkFolderName = "Artwork";
@@ -28,6 +29,13 @@ internal sealed class PathService : IPathService
     public string GetArtworkCacheDirectory() => _artworkCacheBaseDir;
     public string GetGameArtworkCover(string slug) => Path.Combine(_artworkCacheBaseDir,slug,  s_gameCoverFileName);
     public string GetGameArtThumbnailPath(string slug) => Path.Combine(_artworkCacheBaseDir, slug, s_iconFileName);
+    public IReadOnlyList<string> GetSteamLinuxPaths() =>
+    [
+        Path.Combine(s_userProfileDirectory, ".steam", "steam"),
+        Path.Combine(s_userProfileDirectory, ".local", "share", "Steam"),
+        Path.Combine(s_userProfileDirectory, "snap",   "steam", "common", ".local", "share", "Steam")
+    ];
+
     public string GetEpicInstallPath() => Path.Combine(
         s_commonAppDataDirectory, "Epic", "EpicGamesLauncher", "Data", "Manifests");
 

--- a/src/Restall.Infrastructure/Services/PathService.cs
+++ b/src/Restall.Infrastructure/Services/PathService.cs
@@ -8,7 +8,9 @@ internal sealed class PathService : IPathService
     private const string s_appName = "Restall";
 
     private static readonly string s_baseDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), s_appName);
-
+    private static readonly string s_userProfileDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+    private static readonly string s_commonAppDataDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+    
     private const string s_downloadCacheFolderName = "DownloadCache";
     private const string s_cacheFolderName = "Cache";
     private const string s_artworkFolderName = "Artwork";
@@ -26,7 +28,18 @@ internal sealed class PathService : IPathService
     public string GetArtworkCacheDirectory() => _artworkCacheBaseDir;
     public string GetGameArtworkCover(string slug) => Path.Combine(_artworkCacheBaseDir,slug,  s_gameCoverFileName);
     public string GetGameArtThumbnailPath(string slug) => Path.Combine(_artworkCacheBaseDir, slug, s_iconFileName);
+    public string GetEpicInstallPath() => Path.Combine(
+        s_commonAppDataDirectory, "Epic", "EpicGamesLauncher", "Data", "Manifests");
+
+    public string GetEpicHeroicPath() => OperatingSystem.IsWindows()
+        ? Path.Combine(s_userProfileDirectory, "AppData", "Roaming", "heroic", "legendaryConfig", "legendary")
+        : Path.Combine(s_userProfileDirectory, ".config", "heroic", "legendaryConfig", "legendary");
+
+    public string GetGOGHeroicPath() => OperatingSystem.IsWindows()
+        ? Path.Combine(s_userProfileDirectory, "AppData", "Roaming", "heroic", "gog_store")
+        : Path.Combine(s_userProfileDirectory, ".config", "heroic", "gog_store");
     
+
     public string GetReShadeCachePath(ReShade reShade) =>
         Path.Combine(_reShadeCacheBaseDir, reShade.BranchName.ToString(), reShade.Version!);
 

--- a/src/Restall.Infrastructure/Services/PathService.cs
+++ b/src/Restall.Infrastructure/Services/PathService.cs
@@ -11,42 +11,36 @@ internal sealed class PathService : IPathService
     private static readonly string s_userProfileDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
     private static readonly string s_commonAppDataDirectory = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
     
-    
     private const string s_downloadCacheFolderName = "DownloadCache";
     private const string s_cacheFolderName = "Cache";
     private const string s_artworkFolderName = "Artwork";
-    
+
     private const string s_iconFileName = "icon.png";
     private const string s_gameCoverFileName = "cover.png";
-    
+
     private readonly string _defaultLogPath = Path.Combine(s_baseDirectory, "Logs");
     private readonly string _reShadeCacheBaseDir = Path.Combine(s_baseDirectory, s_cacheFolderName, "ReShade");
     private readonly string _reShadeDownloadCacheBaseDir = Path.Combine(s_baseDirectory, s_downloadCacheFolderName, "ReShade");
     private readonly string _renoDXDownloadCacheBaseDir = Path.Combine(s_baseDirectory, s_downloadCacheFolderName, "RenoDX");
     private readonly string _artworkCacheBaseDir = Path.Combine(s_baseDirectory, s_cacheFolderName, s_artworkFolderName);
     
-    
     public string GetArtworkCacheDirectory() => _artworkCacheBaseDir;
-    public string GetGameArtworkCover(string slug) => Path.Combine(_artworkCacheBaseDir,slug,  s_gameCoverFileName);
+    public string GetGameArtworkCover(string slug) => Path.Combine(_artworkCacheBaseDir, slug, s_gameCoverFileName);
     public string GetGameArtThumbnailPath(string slug) => Path.Combine(_artworkCacheBaseDir, slug, s_iconFileName);
+
     public IReadOnlyList<string> GetSteamLinuxPaths() =>
     [
         Path.Combine(s_userProfileDirectory, ".steam", "steam"),
         Path.Combine(s_userProfileDirectory, ".local", "share", "Steam"),
-        Path.Combine(s_userProfileDirectory, "snap",   "steam", "common", ".local", "share", "Steam")
+        Path.Combine(s_userProfileDirectory, "snap", "steam", "common", ".local", "share", "Steam")
     ];
 
-    public string GetEpicInstallPath() => Path.Combine(
-        s_commonAppDataDirectory, "Epic", "EpicGamesLauncher", "Data", "Manifests");
+    public string GetEpicInstallPath() => 
+        Path.Combine(s_commonAppDataDirectory, "Epic", "EpicGamesLauncher", "Data", "Manifests");
 
-    public string GetEpicHeroicPath() => OperatingSystem.IsWindows()
-        ? Path.Combine(s_userProfileDirectory, "AppData", "Roaming", "heroic", "legendaryConfig", "legendary")
-        : Path.Combine(s_userProfileDirectory, ".config", "heroic", "legendaryConfig", "legendary");
-
-    public string GetGOGHeroicPath() => OperatingSystem.IsWindows()
-        ? Path.Combine(s_userProfileDirectory, "AppData", "Roaming", "heroic", "gog_store")
-        : Path.Combine(s_userProfileDirectory, ".config", "heroic", "gog_store");
-    
+    public string GetHeroicPath() => OperatingSystem.IsWindows()
+        ? Path.Combine(s_userProfileDirectory, "AppData", "Roaming", "heroic")
+        : Path.Combine(s_userProfileDirectory, ".config", "heroic");
 
     public string GetReShadeCachePath(ReShade reShade) =>
         Path.Combine(_reShadeCacheBaseDir, reShade.BranchName.ToString(), reShade.Version!);

--- a/src/Restall.Infrastructure/Services/PathService.cs
+++ b/src/Restall.Infrastructure/Services/PathService.cs
@@ -42,6 +42,26 @@ internal sealed class PathService : IPathService
         ? Path.Combine(s_userProfileDirectory, "AppData", "Roaming", "heroic")
         : Path.Combine(s_userProfileDirectory, ".config", "heroic");
 
+    public string GetHeroicInstalledPath(Game.Platform platform) =>
+        (GetHeroicPath() is {} root ? platform switch
+        {
+            Game.Platform.Epic => Path.Combine(root, "legendaryConfig", "legendary", "installed.json"),
+            Game.Platform.GOG => Path.Combine(root, "gog_store", "installed.json"),
+            _ => null
+
+        } : null) ?? "Unknown";
+    
+    public string GetHeroicStoreCache(Game.Platform platform, string destination) =>
+        (GetHeroicPath() is {} root ? platform switch
+        {
+            
+            Game.Platform.Epic => Path.Combine(root, "store_cache", destination),
+            Game.Platform.GOG => Path.Combine(root, "store_cache", destination),
+            _ => null
+
+        } : null) ?? "Unknown";
+    
+
     public string GetReShadeCachePath(ReShade reShade) =>
         Path.Combine(_reShadeCacheBaseDir, reShade.BranchName.ToString(), reShade.Version!);
 

--- a/src/Restall.UI/Views/GameListView.axaml
+++ b/src/Restall.UI/Views/GameListView.axaml
@@ -54,6 +54,7 @@
         <ListBox Grid.Row="1" ItemsSource="{Binding Games}"
                  x:Name="GameList"
                  Classes="game-list"
+                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                  SelectedItem="{Binding SelectedGame}"
                  CornerRadius="6"
                  Margin="8,6"
@@ -85,6 +86,8 @@
                                        Stretch="UniformToFill" />
                             </Border>
                             <TextBlock Text="{Binding Name}"
+                                       TextTrimming="CharacterEllipsis"
+                                       Width="200"
                                        FontSize="12"
                                        Foreground="{DynamicResource GameCardText}"
                                        VerticalAlignment="Center" />

--- a/src/Restall.UI/Views/ModView.axaml
+++ b/src/Restall.UI/Views/ModView.axaml
@@ -32,22 +32,25 @@
                       VerticalAlignment="Top">
                     
                     <!--TODO: ADD ANIMATION FOR RELAYCOMMAND -->
-                    <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="6"
+                    <Grid Grid.Column="0" ColumnDefinitions="*, Auto"
                                 VerticalAlignment="Center">
-                        <TextBlock Text="{Binding SelectedGame.Name}"
+                        <TextBlock Grid.Column="0" 
+                                   Text="{Binding SelectedGame.Name}"
                                    FontSize="20"
                                    FontWeight="Bold" Padding="6,0,0,0"
-                                   Foreground="{DynamicResource GameCardText}" TextWrapping="Wrap"
+                                   Foreground="{DynamicResource GameCardText}" 
+                                   TextWrapping="Wrap"
                                    VerticalAlignment="Center" />
-                        <Button Classes="game-card-btn"
+                        <Button Grid.Column="1" 
+                                Classes="game-card-btn"
                                 CornerRadius="6"
-                                Margin="8,2,0,0"
-                                VerticalAlignment="Center">
+                                Margin="20,0"
+                                HorizontalAlignment="Left">
                             <TextBlock FontFamily="{StaticResource Phosphor-Fill}"
                                        FontSize="16"
                                        Text="&#xE094;" />
                         </Button>
-                    </StackPanel>
+                    </Grid>
                     
                     
                     <TextBlock Grid.Row="1" Text="{Binding SelectedGame.PlatformName}"

--- a/src/Restall.UI/Views/ModView.axaml
+++ b/src/Restall.UI/Views/ModView.axaml
@@ -35,22 +35,26 @@
                     <!--TODO: ADD ANIMATION FOR RELAYCOMMAND -->
                     <Grid Grid.Column="0" ColumnDefinitions="*, Auto"
                                 VerticalAlignment="Center">
-                        <TextBlock Grid.Column="0" 
-                                   Text="{Binding SelectedGame.Name}"
-                                   FontSize="20"
-                                   FontWeight="Bold" Padding="6,0,0,0"
-                                   Foreground="{DynamicResource GameCardText}" 
-                                   TextWrapping="Wrap"
-                                   VerticalAlignment="Center" />
-                        <Button Grid.Column="1" 
-                                Classes="game-card-btn"
-                                CornerRadius="6"
-                                Margin="20,0"
-                                HorizontalAlignment="Left">
-                            <TextBlock FontFamily="{StaticResource Phosphor-Fill}"
-                                       FontSize="16"
-                                       Text="&#xE094;" />
-                        </Button>
+                        <StackPanel Orientation="Horizontal"
+                                    VerticalAlignment="Center">
+                        
+                            <TextBlock Grid.Column="0" 
+                                       Text="{Binding SelectedGame.Name}"
+                                       FontSize="20"
+                                       FontWeight="Bold" Padding="6,0,0,0"
+                                       Foreground="{DynamicResource GameCardText}" 
+                                       TextWrapping="Wrap"
+                                       VerticalAlignment="Center" />
+                            <Button Grid.Column="0" 
+                                    Classes="game-card-btn"
+                                    CornerRadius="6"
+                                    Margin="6,0">
+                                <TextBlock FontFamily="{StaticResource Phosphor-Fill}"
+                                           FontSize="16"
+                                           Text="&#xE094;" />
+                            </Button>   
+                        </StackPanel>
+                        
                     </Grid>
                     
                     


### PR DESCRIPTION
We realized that we were using the same paths in different scripts. So we made the decision to move them into PathService and call the functions from there.

We changed so we are getting the app_name and title from `...._install_info.json` instead of `installed.json`. The reason for that was the titles were too inconsistent on both. GOG didn't store any names and we were at first forced to get the name from the folder and Epic gave out inaccurate titles. Therefore, I am looking for `app_name` and `title` in respective installed_info and store it and then look for app_name in installed.json to get the executable path.

We added following when it comes to paths:

- Steam Linux paths
- Base directory for Heroic
- store_cache for both install_info and library
- installed.json


I also refactored the Views by moving the styling from GameListView to ListBox styles since it was taking up a huge chunk of space in GameListView Views and added Texttrimming along with setting the width. I also updated ModView so long names wont get out of reach by adding it into a Grid. 
