### PR TITLE
Chore/add license notices

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,5 +4,10 @@
         <BaseIntermediateOutputPath>$(MSBuildProjectDirectory)\obj\</BaseIntermediateOutputPath>
         <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
         <RestoreLockedMode>true</RestoreLockedMode>
+        <Product>Restall</Product>
+        <Authors>Johan Lager, Kristofer Sell</Authors>
+        <Copyright>Copyright (C) 2026 Johan Lager &amp; Kristofer Sell</Copyright>
+        <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
+        <RepositoryUrl>https://github.com/fornkatt/Restall</RepositoryUrl>
     </PropertyGroup>
 </Project>

--- a/Restall.sln.DotSettings
+++ b/Restall.sln.DotSettings
@@ -1,4 +1,8 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">SPDX-FileCopyrightText: 2026 Johan Lager &amp; Kristofer Sell
+SPDX-License-Identifier: GPL-3.0-or-later
+</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DX/@EntryIndexedValue">DX</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=EA/@EntryIndexedValue">EA</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GOG/@EntryIndexedValue">GOG</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GOG/@EntryIndexedValue">GOG</s:String>
+	<s:String x:Key="/Default/CustomTools/CustomToolsData/@EntryValue"></s:String></wpf:ResourceDictionary>

--- a/src/Restall.Application/Common/Result.cs
+++ b/src/Restall.Application/Common/Result.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 namespace Restall.Application.Common;
 
 /// <summary>

--- a/src/Restall.Application/DTOs/DownloadProgressReportDto.cs
+++ b/src/Restall.Application/DTOs/DownloadProgressReportDto.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 namespace Restall.Application.DTOs;
 
 public record DownloadProgressReportDto(

--- a/src/Restall.Application/DTOs/GameScanProgressReportDto.cs
+++ b/src/Restall.Application/DTOs/GameScanProgressReportDto.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 namespace Restall.Application.DTOs;
 
 public record GameScanProgressReportDto(

--- a/src/Restall.Application/DTOs/NotesSegmentDto.cs
+++ b/src/Restall.Application/DTOs/NotesSegmentDto.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 namespace Restall.Application.DTOs;
 
 public enum NotesSegmentKind

--- a/src/Restall.Application/DTOs/ReShadeModInfoDto.cs
+++ b/src/Restall.Application/DTOs/ReShadeModInfoDto.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿namespace Restall.Application.DTOs;
 
 /// <summary>

--- a/src/Restall.Application/DTOs/RenoDXGenericModInfoDto.cs
+++ b/src/Restall.Application/DTOs/RenoDXGenericModInfoDto.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿namespace Restall.Application.DTOs;
 
 public record RenoDXGenericModInfoDto(

--- a/src/Restall.Application/DTOs/RenoDXModInfoDto.cs
+++ b/src/Restall.Application/DTOs/RenoDXModInfoDto.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿namespace Restall.Application.DTOs;
 
 public record RenoDXModInfoDto(

--- a/src/Restall.Application/DTOs/RenoDXModPreferenceDto.cs
+++ b/src/Restall.Application/DTOs/RenoDXModPreferenceDto.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿namespace Restall.Application.DTOs;
 
 /// <summary>

--- a/src/Restall.Application/DTOs/RenoDXTagInfoDto.cs
+++ b/src/Restall.Application/DTOs/RenoDXTagInfoDto.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Domain.Entities;
 
 namespace Restall.Application.DTOs;

--- a/src/Restall.Application/DTOs/Results/GameScanResultDto.cs
+++ b/src/Restall.Application/DTOs/Results/GameScanResultDto.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Restall.Domain.Entities;
 
 namespace Restall.Application.DTOs.Results;

--- a/src/Restall.Application/DTOs/Results/ModOperationResultDto.cs
+++ b/src/Restall.Application/DTOs/Results/ModOperationResultDto.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Domain.Entities;
 
 namespace Restall.Application.DTOs.Results;

--- a/src/Restall.Application/DTOs/Results/RefreshLibraryResultDto.cs
+++ b/src/Restall.Application/DTOs/Results/RefreshLibraryResultDto.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Domain.Entities;
 
 namespace Restall.Application.DTOs.Results;

--- a/src/Restall.Application/DTOs/Results/RenoDXWikiParseResultDto.cs
+++ b/src/Restall.Application/DTOs/Results/RenoDXWikiParseResultDto.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using System.Collections.Immutable;
 
 namespace Restall.Application.DTOs.Results;

--- a/src/Restall.Application/DTOs/Results/UpdateCheckResultDto.cs
+++ b/src/Restall.Application/DTOs/Results/UpdateCheckResultDto.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿namespace Restall.Application.DTOs.Results;
 
 // TODO: Error message in DTO? Propagate through Result instead

--- a/src/Restall.Application/Facades/ModManagementFacade.Logging.cs
+++ b/src/Restall.Application/Facades/ModManagementFacade.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Application.Facades;

--- a/src/Restall.Application/Facades/ModManagementFacade.cs
+++ b/src/Restall.Application/Facades/ModManagementFacade.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Microsoft.Extensions.Logging;
 using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;

--- a/src/Restall.Application/Helpers/EmojiShortcodeHelper.cs
+++ b/src/Restall.Application/Helpers/EmojiShortcodeHelper.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.Text.RegularExpressions;
 
 namespace Restall.Application.Helpers;

--- a/src/Restall.Application/Helpers/GameCollectionCatalog.cs
+++ b/src/Restall.Application/Helpers/GameCollectionCatalog.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.Collections.Immutable;
 
 namespace Restall.Application.Helpers;

--- a/src/Restall.Application/Helpers/GameNameHelper.cs
+++ b/src/Restall.Application/Helpers/GameNameHelper.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.Text.RegularExpressions;
 
 namespace Restall.Application.Helpers;

--- a/src/Restall.Application/Helpers/NotesFormattingHelper.cs
+++ b/src/Restall.Application/Helpers/NotesFormattingHelper.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 using Restall.Application.DTOs;

--- a/src/Restall.Application/Helpers/RenoDXWikiModTypeHelper.cs
+++ b/src/Restall.Application/Helpers/RenoDXWikiModTypeHelper.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Restall.Application.DTOs;
 using Restall.Domain.Entities;
 

--- a/src/Restall.Application/Interfaces/Driven/IEngineDetectionService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IEngineDetectionService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Restall.Domain.Entities;
 
 namespace Restall.Application.Interfaces.Driven;

--- a/src/Restall.Application/Interfaces/Driven/IFileExtractionService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IFileExtractionService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.Common;
 
 namespace Restall.Application.Interfaces.Driven;

--- a/src/Restall.Application/Interfaces/Driven/IFileService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IFileService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Restall.Application.Common;
 
 namespace Restall.Application.Interfaces.Driven;

--- a/src/Restall.Application/Interfaces/Driven/IGameArtworkService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IGameArtworkService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Restall.Domain.Entities;
 
 namespace Restall.Application.Interfaces.Driven;

--- a/src/Restall.Application/Interfaces/Driven/IGameCoverService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IGameCoverService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Restall.Domain.Entities;
 
 namespace Restall.Application.Interfaces.Driven;

--- a/src/Restall.Application/Interfaces/Driven/IGameDetectionService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IGameDetectionService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;
 

--- a/src/Restall.Application/Interfaces/Driven/IGameIconService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IGameIconService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 namespace Restall.Application.Interfaces.Driven;
 
 public interface IGameIconService

--- a/src/Restall.Application/Interfaces/Driven/IIconConverterService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IIconConverterService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 namespace Restall.Application.Interfaces.Driven;
 
 public interface IIconConverterService

--- a/src/Restall.Application/Interfaces/Driven/IImageResizeService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IImageResizeService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 namespace Restall.Application.Interfaces.Driven;
 
 public interface IImageResizeService

--- a/src/Restall.Application/Interfaces/Driven/IModCatalog.cs
+++ b/src/Restall.Application/Interfaces/Driven/IModCatalog.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using System.Collections.Immutable;
 using Restall.Application.DTOs;
 

--- a/src/Restall.Application/Interfaces/Driven/IModDetectionService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IModDetectionService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Restall.Application.Common;
 using Restall.Domain.Entities;
 

--- a/src/Restall.Application/Interfaces/Driven/IModDownloadService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IModDownloadService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.Common;
 using Restall.Application.DTOs;
 using Restall.Domain.Entities;

--- a/src/Restall.Application/Interfaces/Driven/IModInstallService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IModInstallService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.Common;
 using Restall.Domain.Entities;
 

--- a/src/Restall.Application/Interfaces/Driven/IParseService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IParseService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.Collections.Immutable;
 using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;

--- a/src/Restall.Application/Interfaces/Driven/IPathService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IPathService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Domain.Entities;
 
 namespace Restall.Application.Interfaces.Driven;

--- a/src/Restall.Application/Interfaces/Driven/IPlatformScannerService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IPlatformScannerService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;
 using Restall.Domain.Entities;

--- a/src/Restall.Application/Interfaces/Driven/IUpdateCheckService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IUpdateCheckService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;
 using Restall.Domain.Entities;

--- a/src/Restall.Application/Interfaces/Driven/IUserPreferencesRepository.cs
+++ b/src/Restall.Application/Interfaces/Driven/IUserPreferencesRepository.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿namespace Restall.Application.Interfaces.Driven;
 
 /// <summary>

--- a/src/Restall.Application/Interfaces/Driven/IVersionCatalog.cs
+++ b/src/Restall.Application/Interfaces/Driven/IVersionCatalog.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.Collections.Immutable;
 using Restall.Application.DTOs;
 using Restall.Domain.Entities;

--- a/src/Restall.Application/Interfaces/Driving/IInstallReShadeUseCase.cs
+++ b/src/Restall.Application/Interfaces/Driving/IInstallReShadeUseCase.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;
 using Restall.Application.UseCases.Requests;

--- a/src/Restall.Application/Interfaces/Driving/IInstallRenoDXUseCase.cs
+++ b/src/Restall.Application/Interfaces/Driving/IInstallRenoDXUseCase.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;
 using Restall.Application.UseCases.Requests;

--- a/src/Restall.Application/Interfaces/Driving/IModManagementFacade.cs
+++ b/src/Restall.Application/Interfaces/Driving/IModManagementFacade.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;
 using Restall.Application.UseCases.Requests;

--- a/src/Restall.Application/Interfaces/Driving/IRefreshLibraryUseCase.cs
+++ b/src/Restall.Application/Interfaces/Driving/IRefreshLibraryUseCase.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;
 using Restall.Domain.Entities;

--- a/src/Restall.Application/Interfaces/Driving/IUninstallReShadeUseCase.cs
+++ b/src/Restall.Application/Interfaces/Driving/IUninstallReShadeUseCase.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.DTOs.Results;
 using Restall.Domain.Entities;
 

--- a/src/Restall.Application/Interfaces/Driving/IUninstallRenoDXUseCase.cs
+++ b/src/Restall.Application/Interfaces/Driving/IUninstallRenoDXUseCase.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.DTOs.Results;
 using Restall.Domain.Entities;
 

--- a/src/Restall.Application/Logging/Log.HeroicScanners.cs
+++ b/src/Restall.Application/Logging/Log.HeroicScanners.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 using Restall.Domain.Entities;
 

--- a/src/Restall.Application/Logging/Log.ModInstall.cs
+++ b/src/Restall.Application/Logging/Log.ModInstall.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Application.Logging;

--- a/src/Restall.Application/Logging/Log.ModUninstall.cs
+++ b/src/Restall.Application/Logging/Log.ModUninstall.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Application.Logging;

--- a/src/Restall.Application/Logging/Log.PeFileFailures.cs
+++ b/src/Restall.Application/Logging/Log.PeFileFailures.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Application.Logging;

--- a/src/Restall.Application/Services/UpdateCheckService.cs
+++ b/src/Restall.Application/Services/UpdateCheckService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;
 using Restall.Application.Interfaces.Driven;

--- a/src/Restall.Application/UseCases/InstallReShadeUseCase.cs
+++ b/src/Restall.Application/UseCases/InstallReShadeUseCase.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Microsoft.Extensions.Logging;
 using Restall.Application.Common;
 using Restall.Application.DTOs;

--- a/src/Restall.Application/UseCases/InstallRenoDXUseCase.Logging.cs
+++ b/src/Restall.Application/UseCases/InstallRenoDXUseCase.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Application.UseCases;

--- a/src/Restall.Application/UseCases/InstallRenoDXUseCase.cs
+++ b/src/Restall.Application/UseCases/InstallRenoDXUseCase.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Microsoft.Extensions.Logging;
 using Restall.Application.Common;
 using Restall.Application.DTOs;

--- a/src/Restall.Application/UseCases/RefreshLibraryUseCase.Logging.cs
+++ b/src/Restall.Application/UseCases/RefreshLibraryUseCase.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Application.UseCases;

--- a/src/Restall.Application/UseCases/RefreshLibraryUseCase.cs
+++ b/src/Restall.Application/UseCases/RefreshLibraryUseCase.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
 using Restall.Application.DTOs;

--- a/src/Restall.Application/UseCases/Requests/InstallReShadeRequest.cs
+++ b/src/Restall.Application/UseCases/Requests/InstallReShadeRequest.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Domain.Entities;
 
 namespace Restall.Application.UseCases.Requests;

--- a/src/Restall.Application/UseCases/Requests/InstallRenoDXRequest.cs
+++ b/src/Restall.Application/UseCases/Requests/InstallRenoDXRequest.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.DTOs;
 using Restall.Domain.Entities;
 

--- a/src/Restall.Application/UseCases/UninstallReShadeUseCase.cs
+++ b/src/Restall.Application/UseCases/UninstallReShadeUseCase.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Microsoft.Extensions.Logging;
 using Restall.Application.Common;
 using Restall.Application.DTOs.Results;

--- a/src/Restall.Application/UseCases/UninstallRenoDXUseCase.cs
+++ b/src/Restall.Application/UseCases/UninstallRenoDXUseCase.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Microsoft.Extensions.Logging;
 using Restall.Application.Common;
 using Restall.Application.DTOs.Results;

--- a/src/Restall.Domain/Entities/Game.cs
+++ b/src/Restall.Domain/Entities/Game.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 namespace Restall.Domain.Entities;
 
 public sealed class Game

--- a/src/Restall.Domain/Entities/ReShade.cs
+++ b/src/Restall.Domain/Entities/ReShade.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 namespace Restall.Domain.Entities;
 
 public sealed class ReShade

--- a/src/Restall.Domain/Entities/RenoDX.cs
+++ b/src/Restall.Domain/Entities/RenoDX.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 namespace Restall.Domain.Entities;
 
 public sealed class RenoDX

--- a/src/Restall.Infrastructure/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Restall.Infrastructure/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using System.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Restall.Application.Facades;

--- a/src/Restall.Infrastructure/Helpers/GameScanHelper.cs
+++ b/src/Restall.Infrastructure/Helpers/GameScanHelper.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.Runtime.Versioning;
 using Microsoft.Win32;
 using System.Text.RegularExpressions;

--- a/src/Restall.Infrastructure/Helpers/PeIconHelper.cs
+++ b/src/Restall.Infrastructure/Helpers/PeIconHelper.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.Text;
 using PeNet;
 

--- a/src/Restall.Infrastructure/Helpers/PeVersionHelper.cs
+++ b/src/Restall.Infrastructure/Helpers/PeVersionHelper.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using System.Security;
 using PeNet;
 using PeNet.Header.Resource;

--- a/src/Restall.Infrastructure/Helpers/RegexHelper.cs
+++ b/src/Restall.Infrastructure/Helpers/RegexHelper.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using System.Text.RegularExpressions;
 
 namespace Restall.Infrastructure.Helpers;

--- a/src/Restall.Infrastructure/Scanners/EAScanner.Logging.cs
+++ b/src/Restall.Infrastructure/Scanners/EAScanner.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Infrastructure.Scanners;

--- a/src/Restall.Infrastructure/Scanners/EAScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/EAScanner.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 using System.Runtime.Versioning;
 using Restall.Application.DTOs.Results;

--- a/src/Restall.Infrastructure/Scanners/EpicScanner.Logging.cs
+++ b/src/Restall.Infrastructure/Scanners/EpicScanner.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Infrastructure.Scanners;

--- a/src/Restall.Infrastructure/Scanners/EpicScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/EpicScanner.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;
 using Restall.Infrastructure.Helpers;

--- a/src/Restall.Infrastructure/Scanners/GOGScanner.Logging.cs
+++ b/src/Restall.Infrastructure/Scanners/GOGScanner.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 

--- a/src/Restall.Infrastructure/Scanners/GOGScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/GOGScanner.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.Runtime.Versioning;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;

--- a/src/Restall.Infrastructure/Scanners/GameExpander.cs
+++ b/src/Restall.Infrastructure/Scanners/GameExpander.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Restall.Application.Helpers;
 using Restall.Domain.Entities;
 

--- a/src/Restall.Infrastructure/Scanners/SteamScanner.Logging.cs
+++ b/src/Restall.Infrastructure/Scanners/SteamScanner.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Infrastructure.Scanners;

--- a/src/Restall.Infrastructure/Scanners/SteamScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/SteamScanner.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;
 using Restall.Infrastructure.Helpers;

--- a/src/Restall.Infrastructure/Scanners/UbisoftScanner.Logging.cs
+++ b/src/Restall.Infrastructure/Scanners/UbisoftScanner.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 

--- a/src/Restall.Infrastructure/Scanners/UbisoftScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/UbisoftScanner.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 using System.Runtime.Versioning;
 using Restall.Application.DTOs.Results;

--- a/src/Restall.Infrastructure/Scanners/XboxScanner.Logging.cs
+++ b/src/Restall.Infrastructure/Scanners/XboxScanner.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Infrastructure.Scanners;

--- a/src/Restall.Infrastructure/Scanners/XboxScanner.cs
+++ b/src/Restall.Infrastructure/Scanners/XboxScanner.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 using Restall.Application.DTOs.Results;

--- a/src/Restall.Infrastructure/Services/EngineDetectionService.Logging.cs
+++ b/src/Restall.Infrastructure/Services/EngineDetectionService.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Infrastructure.Services;

--- a/src/Restall.Infrastructure/Services/EngineDetectionService.cs
+++ b/src/Restall.Infrastructure/Services/EngineDetectionService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;

--- a/src/Restall.Infrastructure/Services/FileExtractionService.cs
+++ b/src/Restall.Infrastructure/Services/FileExtractionService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using System.ComponentModel;
 using Restall.Application.Interfaces.Driven;
 using System.Diagnostics;

--- a/src/Restall.Infrastructure/Services/FileService.cs
+++ b/src/Restall.Infrastructure/Services/FileService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Restall.Application.Common;
 using Restall.Application.Interfaces.Driven;
 using Restall.Infrastructure.Helpers;

--- a/src/Restall.Infrastructure/Services/GameArtworkService.Logging.cs
+++ b/src/Restall.Infrastructure/Services/GameArtworkService.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Infrastructure.Services;

--- a/src/Restall.Infrastructure/Services/GameArtworkService.cs
+++ b/src/Restall.Infrastructure/Services/GameArtworkService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 using Restall.Application.Helpers;
 using Restall.Application.Interfaces.Driven;

--- a/src/Restall.Infrastructure/Services/GameCoverService.Logging.cs
+++ b/src/Restall.Infrastructure/Services/GameCoverService.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Infrastructure.Services;

--- a/src/Restall.Infrastructure/Services/GameCoverService.cs
+++ b/src/Restall.Infrastructure/Services/GameCoverService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Restall.Application.Helpers;

--- a/src/Restall.Infrastructure/Services/GameDetectionService.Logging.cs
+++ b/src/Restall.Infrastructure/Services/GameDetectionService.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 

--- a/src/Restall.Infrastructure/Services/GameDetectionService.cs
+++ b/src/Restall.Infrastructure/Services/GameDetectionService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Restall.Application.DTOs;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;

--- a/src/Restall.Infrastructure/Services/GameIconService.Logging.cs
+++ b/src/Restall.Infrastructure/Services/GameIconService.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Infrastructure.Services;

--- a/src/Restall.Infrastructure/Services/GameIconService.cs
+++ b/src/Restall.Infrastructure/Services/GameIconService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 using Restall.Application.Helpers;
 using Restall.Application.Interfaces.Driven;

--- a/src/Restall.Infrastructure/Services/ModDetectionService.Logging.cs
+++ b/src/Restall.Infrastructure/Services/ModDetectionService.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Infrastructure.Services;

--- a/src/Restall.Infrastructure/Services/ModDetectionService.cs
+++ b/src/Restall.Infrastructure/Services/ModDetectionService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Microsoft.Extensions.Logging;
 using PeNet.Header.Resource;
 using Restall.Application.Common;

--- a/src/Restall.Infrastructure/Services/ModDownloadService.Logging.cs
+++ b/src/Restall.Infrastructure/Services/ModDownloadService.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Microsoft.Extensions.Logging;
 
 namespace Restall.Infrastructure.Services;

--- a/src/Restall.Infrastructure/Services/ModDownloadService.cs
+++ b/src/Restall.Infrastructure/Services/ModDownloadService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using Restall.Application.Common;

--- a/src/Restall.Infrastructure/Services/ModInstallService.cs
+++ b/src/Restall.Infrastructure/Services/ModInstallService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.Common;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;

--- a/src/Restall.Infrastructure/Services/ParseService.Logging.cs
+++ b/src/Restall.Infrastructure/Services/ParseService.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.Net;
 using Microsoft.Extensions.Logging;
 

--- a/src/Restall.Infrastructure/Services/ParseService.cs
+++ b/src/Restall.Infrastructure/Services/ParseService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using System.Collections.Immutable;
 using System.Globalization;
 using System.Text.RegularExpressions;

--- a/src/Restall.Infrastructure/Services/PathService.cs
+++ b/src/Restall.Infrastructure/Services/PathService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;
 

--- a/src/Restall.Infrastructure/Stores/ModCatalog.cs
+++ b/src/Restall.Infrastructure/Stores/ModCatalog.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using System.Collections.Immutable;
 using Restall.Application.DTOs;
 using Restall.Application.Interfaces.Driven;

--- a/src/Restall.Infrastructure/Stores/VersionCatalog.cs
+++ b/src/Restall.Infrastructure/Stores/VersionCatalog.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.Collections.Immutable;
 using Restall.Application.DTOs;
 using Restall.Application.Interfaces.Driven;

--- a/src/Restall.UI/App.axaml.cs
+++ b/src/Restall.UI/App.axaml.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /*
     Restall — ReShade and HDR mod manager
     Copyright (C) 2026  Johan Lager & Kristofer Sell

--- a/src/Restall.UI/App.axaml.cs
+++ b/src/Restall.UI/App.axaml.cs
@@ -1,5 +1,23 @@
+/*
+    Restall — ReShade and HDR mod manager
+    Copyright (C) 2026  Johan Lager & Kristofer Sell
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    Contact us on our GitHub repository:  https://github.com/fornkatt/Restall
+*/
+
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.DependencyInjection;
 using Restall.Infrastructure.Extensions;
@@ -19,7 +37,7 @@ public partial class App : Avalonia.Application
     {
         AvaloniaXamlLoader.Load(this);
     }
-    
+
     public override void OnFrameworkInitializationCompleted()
     {
         // Fall back logging if crash occurs as a last resort during initialization
@@ -41,11 +59,11 @@ public partial class App : Avalonia.Application
 
             Log.Fatal(e.Exception, "Unobserved task exception");
         };
-        
+
         var services = new ServiceCollection();
         ConfigureServices(services);
         var serviceProvider = services.BuildServiceProvider();
-        
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             var startupVm = serviceProvider.GetRequiredService<StartupWindowViewModel>();

--- a/src/Restall.UI/DTOs/ReShadeInstallSelectionDto.cs
+++ b/src/Restall.UI/DTOs/ReShadeInstallSelectionDto.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Domain.Entities;
 
 namespace Restall.UI.DTOs;

--- a/src/Restall.UI/Extensions/UIServiceCollectionExtensions.cs
+++ b/src/Restall.UI/Extensions/UIServiceCollectionExtensions.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Restall.Application.Interfaces.Driven;
 using Restall.UI.Interfaces;

--- a/src/Restall.UI/Interfaces/IModSelectionDialogService.cs
+++ b/src/Restall.UI/Interfaces/IModSelectionDialogService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Restall.Application.DTOs;
 using Restall.UI.DTOs;
 using System.Threading.Tasks;

--- a/src/Restall.UI/Messages/SelectedGameChangedMessage.cs
+++ b/src/Restall.UI/Messages/SelectedGameChangedMessage.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using CommunityToolkit.Mvvm.Messaging.Messages;
 using Restall.UI.ViewModels;
 

--- a/src/Restall.UI/Messages/WikiRefreshedMessage.cs
+++ b/src/Restall.UI/Messages/WikiRefreshedMessage.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿namespace Restall.UI.Messages;
 
 public record WikiRefreshedMessage;

--- a/src/Restall.UI/Program.cs
+++ b/src/Restall.UI/Program.cs
@@ -1,4 +1,7 @@
-﻿/*
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/*
     Restall — ReShade and HDR mod manager
     Copyright (C) 2026  Johan Lager & Kristofer Sell
 

--- a/src/Restall.UI/Program.cs
+++ b/src/Restall.UI/Program.cs
@@ -1,4 +1,23 @@
-﻿using Avalonia;
+﻿/*
+    Restall — ReShade and HDR mod manager
+    Copyright (C) 2026  Johan Lager & Kristofer Sell
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    Contact us on our GitHub repository:  https://github.com/fornkatt/Restall
+*/
+
+using Avalonia;
 using System;
 
 namespace Restall.UI;

--- a/src/Restall.UI/Restall.UI.csproj
+++ b/src/Restall.UI/Restall.UI.csproj
@@ -42,4 +42,8 @@
         <DependentUpon>GameListViewModel.cs</DependentUpon>
       </Compile>
     </ItemGroup>
+
+    <ItemGroup>
+        <Content Include="..\..\LICENSE" CopyToOutputDirectory="PreserveNewest" Link="LICENSE" />
+    </ItemGroup>
 </Project>

--- a/src/Restall.UI/Services/IconConverterService.cs
+++ b/src/Restall.UI/Services/IconConverterService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.IO;
 using Avalonia.Media.Imaging;
 using Restall.Application.Interfaces.Driven;

--- a/src/Restall.UI/Services/ImageResizeService.cs
+++ b/src/Restall.UI/Services/ImageResizeService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System.IO;
 using System.Threading.Tasks;
 using Avalonia.Media.Imaging;

--- a/src/Restall.UI/Services/ModSelectionDialogService.cs
+++ b/src/Restall.UI/Services/ModSelectionDialogService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Avalonia.Controls.ApplicationLifetimes;
 using Restall.Application.DTOs;
 using Restall.Application.Interfaces.Driven;

--- a/src/Restall.UI/ViewLocator.cs
+++ b/src/Restall.UI/ViewLocator.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 using Restall.UI.ViewModels;

--- a/src/Restall.UI/ViewModels/Dialogs/ReShadeInstallDialogViewModel.cs
+++ b/src/Restall.UI/ViewModels/Dialogs/ReShadeInstallDialogViewModel.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Restall.Domain.Entities;

--- a/src/Restall.UI/ViewModels/Dialogs/RenoDXInstallDialogViewModel.cs
+++ b/src/Restall.UI/ViewModels/Dialogs/RenoDXInstallDialogViewModel.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Restall.Application.DTOs;

--- a/src/Restall.UI/ViewModels/GameListViewModel.Logging.cs
+++ b/src/Restall.UI/ViewModels/GameListViewModel.Logging.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using System;
 using Microsoft.Extensions.Logging;
 

--- a/src/Restall.UI/ViewModels/GameListViewModel.cs
+++ b/src/Restall.UI/ViewModels/GameListViewModel.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;

--- a/src/Restall.UI/ViewModels/GameModViewModel.cs
+++ b/src/Restall.UI/ViewModels/GameModViewModel.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Restall.Application.DTOs;

--- a/src/Restall.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Restall.UI/ViewModels/MainWindowViewModel.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using Restall.UI.Messages;

--- a/src/Restall.UI/ViewModels/ModViewModel.cs
+++ b/src/Restall.UI/ViewModels/ModViewModel.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Restall.Application.DTOs;

--- a/src/Restall.UI/ViewModels/StartupWindowViewModel.cs
+++ b/src/Restall.UI/ViewModels/StartupWindowViewModel.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using Restall.Application.DTOs;
 using Restall.Application.Interfaces.Driving;

--- a/src/Restall.UI/ViewModels/ViewModelBase.cs
+++ b/src/Restall.UI/ViewModels/ViewModelBase.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Restall.UI.ViewModels;

--- a/src/Restall.UI/Views/Dialogs/ReShadeInstallDialog.axaml.cs
+++ b/src/Restall.UI/Views/Dialogs/ReShadeInstallDialog.axaml.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Avalonia.Controls;
 using Restall.UI.ViewModels.Dialogs;
 using System;

--- a/src/Restall.UI/Views/Dialogs/RenoDXInstallDialog.axaml.cs
+++ b/src/Restall.UI/Views/Dialogs/RenoDXInstallDialog.axaml.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Avalonia.Controls;
 using Restall.UI.ViewModels.Dialogs;
 using System;

--- a/src/Restall.UI/Views/GameListView.axaml.cs
+++ b/src/Restall.UI/Views/GameListView.axaml.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Avalonia.Controls;
 
 namespace Restall.UI.Views;

--- a/src/Restall.UI/Views/MainWindow.axaml.cs
+++ b/src/Restall.UI/Views/MainWindow.axaml.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Avalonia.Controls;
 
 namespace Restall.UI.Views;

--- a/src/Restall.UI/Views/ModView.axaml.cs
+++ b/src/Restall.UI/Views/ModView.axaml.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Avalonia.Controls;
 
 namespace Restall.UI.Views;

--- a/src/Restall.UI/Views/StartupWindow.axaml.cs
+++ b/src/Restall.UI/Views/StartupWindow.axaml.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Avalonia.Controls;
 
 namespace Restall.UI.Views;


### PR DESCRIPTION
This PR adds full license notices to Program.cs and App.axaml.cs with name of authors, a brief description of the program and where to contact us.

### Overview of changes

- Add full license notices to App.axaml.cs and Program.cs
- Add SPDX headers to all other source files pointing to the license the program is licensed under
    - SPDX headers are automatically added to new source files as per Restall.sln.DotSettings
- Add license metadata to Directory.Build.props so this information gets baked into the binary
- LICENSE file is now copied to output build directory when built