### PR TITLE
Refactor of the Result type

### DIFF
--- a/src/Restall.Application/Common/Enums/ErrorType.cs
+++ b/src/Restall.Application/Common/Enums/ErrorType.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Restall.Application.Common.Enums;
+
+public enum ErrorType
+{
+    None,
+
+    // File extraction
+    ToolNotFound,
+    ExtractionFailed,
+    ProcessStartFailed,
+
+    // Filesystem
+    PermissionDenied,
+    FileSystemError,
+
+    //Network
+    DownloadFailed,
+    NetworkTimeout,
+
+    // Install
+    FileNotFound,
+}

--- a/src/Restall.Application/Common/Enums/WarningType.cs
+++ b/src/Restall.Application/Common/Enums/WarningType.cs
@@ -5,7 +5,5 @@ namespace Restall.Application.Common.Enums;
 
 public enum WarningType
 {
-    None,
-
-
+    None
 }

--- a/src/Restall.Application/Common/Enums/WarningType.cs
+++ b/src/Restall.Application/Common/Enums/WarningType.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Restall.Application.Common.Enums;
+
+public enum WarningType
+{
+    None,
+
+
+}

--- a/src/Restall.Application/Common/Result.cs
+++ b/src/Restall.Application/Common/Result.cs
@@ -1,78 +1,79 @@
 // SPDX-FileCopyrightText: 2026 Johan Lager & Kristofer Sell
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+using Restall.Application.Common.Enums;
+
 namespace Restall.Application.Common;
 
 /// <summary>
-/// A custom Result type that can be used when you do not need to return a value. Auto-sets IsSuccess bool on Success or Error.
-/// Use this type to easily return messages, errors, and exceptions to propagate them for useful logging and user-facing messages.
+/// A custom Result type that can be used when you do not need to return a value.
+/// Auto-sets IsSuccess bool on Success or Error.
+/// Use this type to easily return messages, errors,
+/// and exceptions to propagate them for useful logging and user-facing messages.
 /// </summary>
 /// <remarks>
 ///     <para>
 /// The messages returned by this type should be useful for logging and not be used to write messages to users. Instead,
-/// return an ErrorType with Result.Error and match on the ErrorType in a switch expression to write manual user-friendly messages.
+/// return an ErrorType with Result.Error and match on the ErrorType in a switch expression
+/// to write manual user-friendly messages.
 ///     </para>
 /// </remarks>
 public sealed record Result(
     bool IsSuccess,
-    string? ErrorMessage = null,
+    string? Message = null,
     Exception? Exception = null,
     ErrorType ErrorType = ErrorType.None)
 {
     public static Result Success() => new(true);
 
-    /// <param name="errorMessage">An optional error message.</param>
+    /// <param name="message">An optional error message.</param>
     /// <param name="errorType">An optional error type defined in the ErrorType enum.</param>
     /// <param name="exception">An optional exception.</param>
-    public static Result Error(string? errorMessage, ErrorType errorType = ErrorType.None,
-        Exception? exception = null) => new(false, errorMessage, exception, errorType);
+    public static Result Error(string? message, ErrorType errorType = ErrorType.None,
+        Exception? exception = null) => new(false, message, exception, errorType);
 }
 
 /// <summary>
-/// A custom Result type that can be used as Result<![CDATA[<T>]]> to return a value. Auto-sets IsSuccess bool on Success or Error.
-/// Use this type to easily return messages, errors, and exceptions to propagate them for useful logging and user-facing messages.
+/// A custom Result type that can be used as Result<![CDATA[<T>]]> to return a value.
+/// Created through Success, Partial or Error, which set Status. IsSuccess is true for both Success and Partial,
+/// since both carry a usable value. IsPartial is only true for Partial.
+/// Use this type to easily return messages,
+/// errors, warning, and exceptions to propagate them for useful logging and user-facing messages.
 /// </summary>
 /// <remarks>
 ///     <para>
 /// The messages returned by this type should be useful for logging and not be used to write messages to users. Instead,
-/// return an ErrorType with Result.Error and match on the ErrorType in a switch expression to write manual user-friendly messages.
+/// return an ErrorType with Result.Error or a WarningType with Result.Partial and match on it in a switch expression
+/// to write manual user-friendly messages.
 ///     </para>
 /// </remarks>
 public sealed record Result<T>(
-    bool IsSuccess,
+    ResultStatus Status,
     T? Value = default,
-    string? ErrorMessage = null,
+    string? Message = null,
     Exception? Exception = null,
-    ErrorType ErrorType = ErrorType.None)
+    ErrorType ErrorType = ErrorType.None,
+    WarningType WarningType = WarningType.None)
 {
-    /// <param name="value">T value to return with the success status.</param>
-    public static Result<T> Success(T value) => new(true, value);
+    public bool IsSuccess => Status is not ResultStatus.Error;
+    public bool IsPartial => Status is ResultStatus.Partial;
 
-    /// <param name="errorMessage">An optional error message.</param>
+    /// <param name="value">T value to return with the success status.</param>
+    public static Result<T> Success(T value) => new(ResultStatus.Success, value);
+
+    /// <param name="value">T value to return with the partial status.</param>
+    /// <param name="message">An optional warning message.</param>
+    /// <param name="warningType">An optional warning type defined in the WarningType enum.</param>
+    public static Result<T> Partial(T value, string? message = null,
+        WarningType warningType = WarningType.None) =>
+        new(ResultStatus.Partial, value, message, WarningType: warningType);
+
+    /// <param name="message">An optional error message.</param>
     /// <param name="errorType">An optional error type defined in the ErrorType enum.</param>
     /// <param name="exception">An optional exception.</param>
-    public static Result<T> Error(string? errorMessage, ErrorType errorType = ErrorType.None,
+    public static Result<T> Error(string? message = null, ErrorType errorType = ErrorType.None,
         Exception? exception = null) =>
-        new(false, ErrorMessage: errorMessage, Exception: exception, ErrorType: errorType);
+        new(ResultStatus.Error, Message: message, Exception: exception, ErrorType: errorType);
 }
 
-public enum ErrorType
-{
-    None,
-
-    // File extraction
-    ToolNotFound,
-    ExtractionFailed,
-    ProcessStartFailed,
-
-    // Filesystem
-    PermissionDenied,
-    FileSystemError,
-
-    //Network
-    DownloadFailed,
-    NetworkTimeout,
-
-    // Install
-    FileNotFound,
-}
+public enum ResultStatus { Success, Partial, Error }

--- a/src/Restall.Application/Interfaces/Driven/IFileExtractionService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IFileExtractionService.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using Restall.Application.Common;
+using Restall.Application.Common.Enums;
 
 namespace Restall.Application.Interfaces.Driven;
 

--- a/src/Restall.Application/Interfaces/Driven/IFileService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IFileService.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using Restall.Application.Common;
+using Restall.Application.Common.Enums;
 
 namespace Restall.Application.Interfaces.Driven;
 

--- a/src/Restall.Application/Interfaces/Driven/IModDetectionService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IModDetectionService.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using Restall.Application.Common;
+using Restall.Application.Common.Enums;
 using Restall.Domain.Entities;
 
 namespace Restall.Application.Interfaces.Driven;

--- a/src/Restall.Application/Interfaces/Driven/IModDownloadService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IModDownloadService.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using Restall.Application.Common;
+using Restall.Application.Common.Enums;
 using Restall.Application.DTOs;
 using Restall.Domain.Entities;
 

--- a/src/Restall.Application/Interfaces/Driven/IModInstallService.cs
+++ b/src/Restall.Application/Interfaces/Driven/IModInstallService.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using Restall.Application.Common;
+using Restall.Application.Common.Enums;
 using Restall.Domain.Entities;
 
 namespace Restall.Application.Interfaces.Driven;

--- a/src/Restall.Application/UseCases/InstallReShadeUseCase.cs
+++ b/src/Restall.Application/UseCases/InstallReShadeUseCase.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 using Restall.Application.Common;
+using Restall.Application.Common.Enums;
 using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;
 using Restall.Application.Interfaces.Driven;
@@ -79,7 +80,7 @@ public sealed class InstallReShadeUseCase : IInstallReShadeUseCase
                 };
 
                 _logger.ModDownloadFailure("ReShade", _pathService.GetReShadeDownloadCacheDirectory(reShade.BranchName),
-                    downloadResult.ErrorMessage, downloadResult.Exception);
+                    downloadResult.Message, downloadResult.Exception);
 
                 return new ModOperationResultDto(false, request.Game, userMessage);
             }
@@ -112,7 +113,7 @@ public sealed class InstallReShadeUseCase : IInstallReShadeUseCase
                     _ => "An unexpected error occured during file extraction. Check logs for more details."
                 };
 
-                _logger.ModExtractionFailure("ReShade", extractedCacheDir, extractionResult.ErrorMessage,
+                _logger.ModExtractionFailure("ReShade", extractedCacheDir, extractionResult.Message,
                     extractionResult.Exception);
 
                 return new ModOperationResultDto(false, request.Game, userMessage);
@@ -142,7 +143,7 @@ public sealed class InstallReShadeUseCase : IInstallReShadeUseCase
                 };
 
                 _logger.ExistingModFileDeletionFailure("ReShade", request.Game.Name ?? "Unknown",
-                    deleteResult.ErrorMessage, deleteResult.Exception);
+                    deleteResult.Message, deleteResult.Exception);
 
                 return new ModOperationResultDto(false, request.Game, userMessage);
             }
@@ -163,7 +164,7 @@ public sealed class InstallReShadeUseCase : IInstallReShadeUseCase
                 _ => "Failed to install ReShade. Check logs for details."
             };
 
-            _logger.ModInstallationFailure("ReShade", request.Game.Name ?? "Unknown", result.ErrorMessage,
+            _logger.ModInstallationFailure("ReShade", request.Game.Name ?? "Unknown", result.Message,
                 result.Exception);
 
             return new ModOperationResultDto(false, request.Game, userMessage);

--- a/src/Restall.Application/UseCases/InstallRenoDXUseCase.cs
+++ b/src/Restall.Application/UseCases/InstallRenoDXUseCase.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 using Restall.Application.Common;
+using Restall.Application.Common.Enums;
 using Restall.Application.DTOs;
 using Restall.Application.DTOs.Results;
 using Restall.Application.Helpers;
@@ -105,7 +106,7 @@ public sealed partial class InstallRenoDXUseCase : IInstallRenoDXUseCase
             };
 
             _logger.ModDownloadFailure("RenoDX", _pathService.GetRenoDXDownloadCacheDirectory(renoDX.BranchName),
-                downloadResult.ErrorMessage, downloadResult.Exception);
+                downloadResult.Message, downloadResult.Exception);
 
             return new ModOperationResultDto(false, request.Game, userMessage);
         }
@@ -115,7 +116,7 @@ public sealed partial class InstallRenoDXUseCase : IInstallRenoDXUseCase
         var renoDxVersion = _modDetectionService.GetRenoDXFileVersion(filePath);
 
         if (!renoDxVersion.IsSuccess)
-            LogRenoDXVersionReadFailure(addonFilename, request.Game.Name ?? "Unknown", renoDxVersion.ErrorMessage,
+            LogRenoDXVersionReadFailure(addonFilename, request.Game.Name ?? "Unknown", renoDxVersion.Message,
                 renoDxVersion.Exception);
 
         renoDX.Version = renoDxVersion.Value;
@@ -143,7 +144,7 @@ public sealed partial class InstallRenoDXUseCase : IInstallRenoDXUseCase
                 };
 
                 _logger.ExistingModFileDeletionFailure("RenoDX", request.Game.Name ?? "Unknown",
-                    deleteResult.ErrorMessage, deleteResult.Exception);
+                    deleteResult.Message, deleteResult.Exception);
 
                 return new ModOperationResultDto(false, request.Game, userMessage);
             }
@@ -163,7 +164,7 @@ public sealed partial class InstallRenoDXUseCase : IInstallRenoDXUseCase
                 _ => $"Failed to install {addonFilename}. Check log for details."
             };
 
-            _logger.ModInstallationFailure("RenoDX", request.Game.Name ?? "Unknown", installResult.ErrorMessage,
+            _logger.ModInstallationFailure("RenoDX", request.Game.Name ?? "Unknown", installResult.Message,
                 installResult.Exception);
 
             return new ModOperationResultDto(false, request.Game, userMessage);
@@ -202,7 +203,7 @@ public sealed partial class InstallRenoDXUseCase : IInstallRenoDXUseCase
 
         // TODO: develop proper failure path? A stale file might give the user a version different from what was requested
         if (!deleted.IsSuccess)
-            LogRenoDXStaleCacheDeletionFailure(cachedFilePath, deleted.ErrorMessage, deleted.Exception);
+            LogRenoDXStaleCacheDeletionFailure(cachedFilePath, deleted.Message, deleted.Exception);
     }
 
     private static bool IsCacheOutdated(string? cachedVersion, string? targetVersion)

--- a/src/Restall.Application/UseCases/UninstallReShadeUseCase.cs
+++ b/src/Restall.Application/UseCases/UninstallReShadeUseCase.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 using Restall.Application.Common;
+using Restall.Application.Common.Enums;
 using Restall.Application.DTOs.Results;
 using Restall.Application.Interfaces.Driven;
 using Restall.Application.Interfaces.Driving;
@@ -49,7 +50,7 @@ public sealed class UninstallReShadeUseCase : IUninstallReShadeUseCase
                 _ => $"Failed to uninstall ReShade from {gameName}. Check the log for details."
             };
 
-            _logger.ModUninstallFailure("ReShade", gameName, result.ErrorMessage, result.Exception);
+            _logger.ModUninstallFailure("ReShade", gameName, result.Message, result.Exception);
 
             return new ModOperationResultDto(false, game, userMessage);
         }

--- a/src/Restall.Application/UseCases/UninstallRenoDXUseCase.cs
+++ b/src/Restall.Application/UseCases/UninstallRenoDXUseCase.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 using Restall.Application.Common;
+using Restall.Application.Common.Enums;
 using Restall.Application.DTOs.Results;
 using Restall.Application.Interfaces.Driven;
 using Restall.Application.Interfaces.Driving;
@@ -48,7 +49,7 @@ public sealed class UninstallRenoDXUseCase : IUninstallRenoDXUseCase
                 _ => $"Failed to uninstall RenoDX from {gameName}. Check the log for details."
             };
 
-            _logger.ModUninstallFailure("RenoDX", gameName, result.ErrorMessage, result.Exception);
+            _logger.ModUninstallFailure("RenoDX", gameName, result.Message, result.Exception);
 
             return new ModOperationResultDto(false, game, userMessage);
         }

--- a/src/Restall.Infrastructure/Services/FileExtractionService.cs
+++ b/src/Restall.Infrastructure/Services/FileExtractionService.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using Restall.Application.Interfaces.Driven;
 using System.Diagnostics;
 using Restall.Application.Common;
+using Restall.Application.Common.Enums;
 
 namespace Restall.Infrastructure.Services;
 

--- a/src/Restall.Infrastructure/Services/FileService.cs
+++ b/src/Restall.Infrastructure/Services/FileService.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using Restall.Application.Common;
+using Restall.Application.Common.Enums;
 using Restall.Application.Interfaces.Driven;
 using Restall.Infrastructure.Helpers;
 

--- a/src/Restall.Infrastructure/Services/ModDetectionService.cs
+++ b/src/Restall.Infrastructure/Services/ModDetectionService.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Logging;
 using PeNet.Header.Resource;
 using Restall.Application.Common;
+using Restall.Application.Common.Enums;
 using Restall.Application.Interfaces.Driven;
 using Restall.Application.Logging;
 using Restall.Domain.Entities;

--- a/src/Restall.Infrastructure/Services/ModDownloadService.cs
+++ b/src/Restall.Infrastructure/Services/ModDownloadService.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using Restall.Application.Common;
+using Restall.Application.Common.Enums;
 using Restall.Application.DTOs;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;

--- a/src/Restall.Infrastructure/Services/ModInstallService.cs
+++ b/src/Restall.Infrastructure/Services/ModInstallService.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 using Restall.Application.Common;
+using Restall.Application.Common.Enums;
 using Restall.Application.Interfaces.Driven;
 using Restall.Domain.Entities;
 using Restall.Infrastructure.Helpers;
@@ -62,7 +63,7 @@ internal sealed class ModInstallService : IModInstallService
         var deleted = _fileService.TryDeleteFile(expectedPath);
 
         if (!deleted.IsSuccess)
-            return Result<Game>.Error(deleted.ErrorMessage, deleted.ErrorType, deleted.Exception);
+            return Result<Game>.Error(deleted.Message, deleted.ErrorType, deleted.Exception);
 
         game.ReShade = null;
         return Result<Game>.Success(game);
@@ -74,7 +75,7 @@ internal sealed class ModInstallService : IModInstallService
         var deleted = _fileService.TryDeleteFile(expectedPath, verifyOriginalFilename: "renodx-");
 
         if (!deleted.IsSuccess)
-            return Result<Game>.Error(deleted.ErrorMessage, deleted.ErrorType, deleted.Exception);
+            return Result<Game>.Error(deleted.Message, deleted.ErrorType, deleted.Exception);
 
         game.RenoDX = null;
         return Result<Game>.Success(game);


### PR DESCRIPTION
This PR refactors the `Result` type and adds a `Partial` type.

### Overview of changes:

- Add `Partial` type to `Result<T>`
    - Since a success status can be partial, this gives us an easy way to return a `Partial` type with an option message and `WarningType` (enum) to the caller
    - Useful when the action was successful, but with a degraded value. For instance, game scan was successful but some games/scanners failed
- Rename `ErrorMessage` to `Message` since it's not always an error message anymore
- Add `WarningType` enum
- Move `WarningType` and `ErrorType` to `Application/Common/Enums` so they get their own files to grow in. `Common` because they are shared among the projects
- Refactor `Result` summary to reflect the changes