### PR TITLE
Fix a potential issue where StipCollectionPartSuffix could return a n…

### DIFF
--- a/src/Restall.Application/Helpers/GameNameHelper.cs
+++ b/src/Restall.Application/Helpers/GameNameHelper.cs
@@ -69,7 +69,7 @@ public static partial class GameNameHelper
     public static string StripCollectionPartSuffix(string name)
     {
         if (string.IsNullOrWhiteSpace(name))
-            return name;
+            return string.Empty;
 
         var collection = GameCollectionCatalog.All.FirstOrDefault(d =>
             d.CollapseForModMatching && d.Matches(name));


### PR DESCRIPTION
This PR fixes a potential null return in `StripCollectionPartSuffix()` after a `IsNullOrWhiteSpace` guard. Instead we sanitise the input string and return it empty.